### PR TITLE
unbreak timers.

### DIFF
--- a/src/timer.rs
+++ b/src/timer.rs
@@ -134,3 +134,14 @@ impl Future for Timer {
         }
     }
 }
+
+#[test]
+fn basic_timer_works() {
+    test_executor!(
+        async move {
+            let now = Instant::now();
+            Timer::new(Duration::from_millis(100)).await;
+            assert!(now.elapsed().as_millis() >= 100)
+        }
+    );
+}


### PR DESCRIPTION
### What does this PR do?

It fixes(*) the timer code so timers work. It also adds a very basic unit test to make sure they keep working.
I never paid attention to timers at first because I had no need for then, but the time has come.

I don't consider timers really fixed: they are quite inefficient, leading the io_uring to return EBUSY (it shouldn't, and I still don't fully know why), so more work is needed.

However with this PR they at least return so let's take this step.

### Checklist

[x] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
[x] The new code I am adding is formatted using `rustfmt`
