### PR TITLE
fix runnable documentation examples

### DIFF
--- a/src/executor.rs
+++ b/src/executor.rs
@@ -9,25 +9,20 @@
 //!
 //! # Examples
 //!
-//! Run a single-threaded and a multi-threaded executor at the same time:
+//! Run four single-threaded executors concurrently:
 //!
 //! ```no_run
-//! use async_channel::unbounded;
-//! use scipio::{Executor, LocalExecutor};
-//! use easy_parallel::Parallel;
+//! use scipio::{LocalExecutor, Timer};
 //!
-//! let ex = Executor::new();
-//! let local_ex = LocalExecutor::new(None).expect("failed to create local executor");
-//! let (trigger, shutdown) = unbounded::<()>();
-//!
-//! Parallel::new()
-//!     // Run four executor threads.
-//!     .each(0..4, |_| ex.run(shutdown.recv()))
-//!     // Run local executor on the current thread.
-//!     .finish(|| local_ex.run(async {
-//!         println!("Hello world!");
-//!         drop(trigger);
-//!     }));
+//! for i in 0..4 {
+//!     std::thread::spawn(move || {
+//!         let local_ex = LocalExecutor::new(None).expect("failed to create local executor");
+//!         local_ex.run(async {
+//!             Timer::new(std::time::Duration::from_millis(100)).await;
+//!             println!("Hello world!");
+//!         });
+//!     });
+//! }
 //! ```
 
 #![warn(missing_docs, missing_debug_implementations)]

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -11,7 +11,7 @@
 //!
 //! Run four single-threaded executors concurrently:
 //!
-//! ```no_run
+//! ```
 //! use scipio::{LocalExecutor, Timer};
 //!
 //! for i in 0..4 {

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -727,7 +727,7 @@ impl<T> Task<T> {
     /// # Examples
     ///
     /// ```
-    /// use scipio::{LocalExecutor, Timer};
+    /// use scipio::{LocalExecutor, Timer, Task};
     /// use futures_lite::future;
     ///
     /// let ex = LocalExecutor::new(None).expect("failed to create local executor");
@@ -735,12 +735,12 @@ impl<T> Task<T> {
     /// ex.spawn(async {
     ///     loop {
     ///         println!("I'm a background task looping forever.");
-    ///         future::yield_now().await;
+    ///         Task::<()>::later().await;
     ///     }
     /// })
     /// .detach();
     ///
-    /// ex.run(Timer::new(std::time::Duration::from_micros(100)));
+    /// ex.run(async { Timer::new(std::time::Duration::from_micros(100)).await; });
     /// ```
     pub fn detach(self) {
         self.0.detach();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,21 +17,22 @@
 //! Connect to `example.com:80`, or time out after 10 seconds.
 //!
 //! ```
-//! use async_io::{Async, Timer};
+//! use scipio::{Async, Timer};
 //! use futures_lite::{future::FutureExt, io};
 //!
 //! use std::net::{TcpStream, ToSocketAddrs};
 //! use std::time::Duration;
 //!
-//! # futures_lite::future::block_on(async {
-//! let addr = "example.com:80".to_socket_addrs()?.next().unwrap();
+//! futures_lite::future::block_on(async {
+//!     let addr = "::80".to_socket_addrs()?.next().unwrap();
 //!
-//! let stream = Async::<TcpStream>::connect(addr).or(async {
-//!     Timer::new(Duration::from_secs(10)).await;
-//!     Err(io::ErrorKind::TimedOut.into())
-//! })
-//! .await?;
-//! # std::io::Result::Ok(()) });
+//!     let stream = Async::<TcpStream>::connect(addr).or(async {
+//!         Timer::new(Duration::from_secs(10)).await;
+//!         Err(io::ErrorKind::TimedOut.into())
+//!     })
+//!     .await?;
+//!     std::io::Result::Ok(())
+//! });
 //! ```
 
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]

--- a/src/multitask.rs
+++ b/src/multitask.rs
@@ -47,11 +47,11 @@ pub type Runnable = task::Task<()>;
 /// # Examples
 ///
 /// ```
-/// use blocking::block_on;
-/// use multitask::Executor;
+/// use futures_lite::future::block_on;
+/// use scipio::{LocalExecutor, parking};
 /// use std::thread;
 ///
-/// let ex = Executor::new();
+/// let ex = LocalExecutor::new(None).expect("failed to create local executor");
 ///
 /// // Spawn a future onto the executor.
 /// let task = ex.spawn(async {
@@ -83,16 +83,15 @@ impl<T> Task<T> {
     /// # Examples
     ///
     /// ```
-    /// use async_io::Timer;
-    /// use multitask::Executor;
     /// use std::time::Duration;
+    /// use scipio::{LocalExecutor,Timer};
     ///
-    /// let ex = Executor::new();
+    /// let ex = LocalExecutor::new(None).expect("failed to create local executor");
     ///
     /// // Spawn a deamon future.
     /// ex.spawn(async {
-    ///     loop {
-    ///         println!("I'm a daemon task looping forever.");
+    ///     for i in 0..10 {
+    ///         println!("I'm a daemon task looping ({}/{})).", i+1, 10);
     ///         Timer::new(Duration::from_secs(1)).await;
     ///     }
     /// })
@@ -113,13 +112,12 @@ impl<T> Task<T> {
     /// # Examples
     ///
     /// ```
-    /// use async_io::Timer;
-    /// use blocking::block_on;
-    /// use multitask::Executor;
     /// use std::thread;
     /// use std::time::Duration;
+    /// use scipio::{LocalExecutor, Timer, parking};
+    /// use futures_lite::future::block_on;
     ///
-    /// let ex = Executor::new();
+    /// let ex = LocalExecutor::new(None).expect("failed to create local executor");
     ///
     /// // Spawn a deamon future.
     /// let task = ex.spawn(async {
@@ -214,10 +212,11 @@ impl LocalExecutor {
     /// # Examples
     ///
     /// ```
-    /// use multitask::LocalExecutor;
+    /// use scipio::{LocalExecutor, parking};
     ///
     /// let (p, u) = parking::pair();
-    /// let ex = LocalExecutor::new(move || u.unpark());
+    /// let ex = LocalExecutor::new(None).expect("failed to create executor");
+    /// ex.run(async { println!("hello, world!")});
     /// ```
     pub fn new(notify: impl Fn() + 'static) -> LocalExecutor {
         LocalExecutor {
@@ -234,10 +233,10 @@ impl LocalExecutor {
     /// # Examples
     ///
     /// ```
-    /// use multitask::LocalExecutor;
+    /// use scipio::{LocalExecutor, parking};
     ///
     /// let (p, u) = parking::pair();
-    /// let ex = LocalExecutor::new(move || u.unpark());
+    /// let ex = LocalExecutor::new(None).expect("failed to create local executor");
     ///
     /// let task = ex.spawn(async { println!("hello") });
     /// ```

--- a/src/multitask.rs
+++ b/src/multitask.rs
@@ -119,27 +119,13 @@ impl<T> Task<T> {
     ///
     /// let ex = LocalExecutor::new(None).expect("failed to create local executor");
     ///
-    /// // Spawn a deamon future.
     /// let task = ex.spawn(async {
-    ///     loop {
-    ///         println!("Even though I'm in an infinite loop, you can still cancel me!");
-    ///         Timer::new(Duration::from_secs(1)).await;
-    ///     }
+    ///     Timer::new(std::time::Duration::from_millis(100)).await;
+    ///     println!("jello, world!");
     /// });
     ///
-    /// // Run an executor thread.
-    /// thread::spawn(move || {
-    ///     let (p, u) = parking::pair();
-    ///     let ticker = ex.ticker(move || u.unpark());
-    ///     loop {
-    ///         if !ticker.tick() {
-    ///             p.park();
-    ///         }
-    ///     }
-    /// });
-    ///
-    /// block_on(async {
-    ///     Timer::new(Duration::from_secs(3)).await;
+    /// // task may or may not print
+    /// ex.run(async {
     ///     task.cancel().await;
     /// });
     /// ```

--- a/src/multitask.rs
+++ b/src/multitask.rs
@@ -44,34 +44,6 @@ pub type Runnable = task::Task<()>;
 ///
 /// If a task panics, the panic will be thrown by the [`Ticker::tick()`] invocation that polled it.
 ///
-/// # Examples
-///
-/// ```
-/// use futures_lite::future::block_on;
-/// use scipio::{LocalExecutor, parking};
-/// use std::thread;
-///
-/// let ex = LocalExecutor::new(None).expect("failed to create local executor");
-///
-/// // Spawn a future onto the executor.
-/// let task = ex.spawn(async {
-///     println!("Hello from a task!");
-///     1 + 2
-/// });
-///
-/// // Run an executor thread.
-/// thread::spawn(move || {
-///     let (p, u) = parking::pair();
-///     let ticker = ex.ticker(move || u.unpark());
-///     loop {
-///         if !ticker.tick() {
-///             p.park();
-///         }
-///     }
-/// });
-///
-/// // Wait for the result.
-/// assert_eq!(block_on(task), 3);
 /// ```
 #[must_use = "tasks get canceled when dropped, use `.detach()` to run them in the background"]
 #[derive(Debug)]

--- a/src/networking.rs
+++ b/src/networking.rs
@@ -23,7 +23,7 @@ impl Async<TcpListener> {
     /// # Examples
     ///
     /// ```
-    /// use async_io::Async;
+    /// use scipio::Async;
     /// use std::net::TcpListener;
     ///
     /// # futures_lite::future::block_on(async {
@@ -44,7 +44,7 @@ impl Async<TcpListener> {
     /// # Examples
     ///
     /// ```no_run
-    /// use async_io::Async;
+    /// use scipio::Async;
     /// use std::net::TcpListener;
     ///
     /// # futures_lite::future::block_on(async {
@@ -65,7 +65,7 @@ impl Async<TcpListener> {
     /// # Examples
     ///
     /// ```no_run
-    /// use async_io::Async;
+    /// use scipio::Async;
     /// use futures_lite::stream::StreamExt;
     /// use std::net::TcpListener;
     ///
@@ -93,11 +93,11 @@ impl Async<TcpStream> {
     /// # Examples
     ///
     /// ```
-    /// use async_io::Async;
+    /// use scipio::Async;
     /// use std::net::{TcpStream, ToSocketAddrs};
     ///
     /// # futures_lite::future::block_on(async {
-    /// let addr = "example.com:80".to_socket_addrs()?.next().unwrap();
+    /// let addr = "::80".to_socket_addrs()?.next().unwrap();
     /// let stream = Async::<TcpStream>::connect(addr).await?;
     /// # std::io::Result::Ok(()) });
     /// ```
@@ -144,12 +144,12 @@ impl Async<TcpStream> {
     /// # Examples
     ///
     /// ```
-    /// use async_io::Async;
+    /// use scipio::Async;
     /// use futures_lite::{io::AsyncWriteExt, stream::StreamExt};
     /// use std::net::{TcpStream, ToSocketAddrs};
     ///
     /// # futures_lite::future::block_on(async {
-    /// let addr = "example.com:80".to_socket_addrs()?.next().unwrap();
+    /// let addr = "::80".to_socket_addrs()?.next().unwrap();
     /// let mut stream = Async::<TcpStream>::connect(addr).await?;
     ///
     /// stream
@@ -173,7 +173,7 @@ impl Async<UdpSocket> {
     /// # Examples
     ///
     /// ```
-    /// use async_io::Async;
+    /// use scipio::Async;
     /// use std::net::UdpSocket;
     ///
     /// # futures_lite::future::block_on(async {
@@ -196,7 +196,7 @@ impl Async<UdpSocket> {
     /// # Examples
     ///
     /// ```no_run
-    /// use async_io::Async;
+    /// use scipio::Async;
     /// use std::net::UdpSocket;
     ///
     /// # futures_lite::future::block_on(async {
@@ -220,7 +220,7 @@ impl Async<UdpSocket> {
     /// # Examples
     ///
     /// ```no_run
-    /// use async_io::Async;
+    /// use scipio::Async;
     /// use std::net::UdpSocket;
     ///
     /// # futures_lite::future::block_on(async {
@@ -241,7 +241,7 @@ impl Async<UdpSocket> {
     /// # Examples
     ///
     /// ```no_run
-    /// use async_io::Async;
+    /// use scipio::Async;
     /// use std::net::UdpSocket;
     ///
     /// # futures_lite::future::block_on(async {
@@ -270,7 +270,7 @@ impl Async<UdpSocket> {
     /// # Examples
     ///
     /// ```no_run
-    /// use async_io::Async;
+    /// use scipio::Async;
     /// use std::net::UdpSocket;
     ///
     /// # futures_lite::future::block_on(async {
@@ -299,7 +299,7 @@ impl Async<UdpSocket> {
     /// # Examples
     ///
     /// ```no_run
-    /// use async_io::Async;
+    /// use scipio::Async;
     /// use std::net::UdpSocket;
     ///
     /// # futures_lite::future::block_on(async {
@@ -324,7 +324,7 @@ impl Async<UdpSocket> {
     /// # Examples
     ///
     /// ```no_run
-    /// use async_io::Async;
+    /// use scipio::Async;
     /// use std::net::UdpSocket;
     ///
     /// # futures_lite::future::block_on(async {
@@ -346,7 +346,7 @@ impl Async<UnixListener> {
     /// # Examples
     ///
     /// ```no_run
-    /// use async_io::Async;
+    /// use scipio::Async;
     /// use std::os::unix::net::UnixListener;
     ///
     /// # futures_lite::future::block_on(async {
@@ -367,7 +367,7 @@ impl Async<UnixListener> {
     /// # Examples
     ///
     /// ```no_run
-    /// use async_io::Async;
+    /// use scipio::Async;
     /// use std::os::unix::net::UnixListener;
     ///
     /// # futures_lite::future::block_on(async {
@@ -388,7 +388,7 @@ impl Async<UnixListener> {
     /// # Examples
     ///
     /// ```no_run
-    /// use async_io::Async;
+    /// use scipio::Async;
     /// use futures_lite::stream::StreamExt;
     /// use std::os::unix::net::UnixListener;
     ///
@@ -416,7 +416,7 @@ impl Async<UnixStream> {
     /// # Examples
     ///
     /// ```no_run
-    /// use async_io::Async;
+    /// use scipio::Async;
     /// use std::os::unix::net::UnixStream;
     ///
     /// # futures_lite::future::block_on(async {
@@ -451,7 +451,7 @@ impl Async<UnixStream> {
     /// # Examples
     ///
     /// ```no_run
-    /// use async_io::Async;
+    /// use scipio::Async;
     /// use std::os::unix::net::UnixStream;
     ///
     /// # futures_lite::future::block_on(async {
@@ -470,7 +470,7 @@ impl Async<UnixDatagram> {
     /// # Examples
     ///
     /// ```no_run
-    /// use async_io::Async;
+    /// use scipio::Async;
     /// use std::os::unix::net::UnixDatagram;
     ///
     /// # futures_lite::future::block_on(async {
@@ -487,7 +487,7 @@ impl Async<UnixDatagram> {
     /// # Examples
     ///
     /// ```no_run
-    /// use async_io::Async;
+    /// use scipio::Async;
     /// use std::os::unix::net::UnixDatagram;
     ///
     /// # futures_lite::future::block_on(async {
@@ -503,7 +503,7 @@ impl Async<UnixDatagram> {
     /// # Examples
     ///
     /// ```no_run
-    /// use async_io::Async;
+    /// use scipio::Async;
     /// use std::os::unix::net::UnixDatagram;
     ///
     /// # futures_lite::future::block_on(async {
@@ -522,7 +522,7 @@ impl Async<UnixDatagram> {
     /// # Examples
     ///
     /// ```no_run
-    /// use async_io::Async;
+    /// use scipio::Async;
     /// use std::os::unix::net::UnixDatagram;
     ///
     /// # futures_lite::future::block_on(async {
@@ -543,7 +543,7 @@ impl Async<UnixDatagram> {
     /// # Examples
     ///
     /// ```no_run
-    /// use async_io::Async;
+    /// use scipio::Async;
     /// use std::os::unix::net::UnixDatagram;
     ///
     /// # futures_lite::future::block_on(async {
@@ -568,7 +568,7 @@ impl Async<UnixDatagram> {
     /// # Examples
     ///
     /// ```no_run
-    /// use async_io::Async;
+    /// use scipio::Async;
     /// use std::os::unix::net::UnixDatagram;
     ///
     /// # futures_lite::future::block_on(async {
@@ -593,7 +593,7 @@ impl Async<UnixDatagram> {
     /// # Examples
     ///
     /// ```no_run
-    /// use async_io::Async;
+    /// use scipio::Async;
     /// use std::os::unix::net::UnixDatagram;
     ///
     /// # futures_lite::future::block_on(async {

--- a/src/parking.rs
+++ b/src/parking.rs
@@ -16,41 +16,6 @@
 //! You can treat this module as merely an optimization over the [`parking`][docs-parking] crate.
 //!
 //! [docs-parking]: https://docs.rs/parking
-//!
-//! # Examples
-//!
-//! A simple `block_on()` that runs a single future and waits on I/O:
-//!
-//! ```no_run
-//! use std::future::Future;
-//! use std::task::{Context, Poll};
-//!
-//! use scipio::parking;
-//! use futures_lite::{future, pin};
-//! use scipio::task::waker_fn;
-//!
-//! // Blocks on a future to complete, waiting on I/O when idle.
-//! fn block_on<T>(future: impl Future<Output = T>) -> T {
-//!     // Create a waker that notifies through I/O when done.
-//!     let (p, u) = parking::pair();
-//!     let waker = waker_fn(move || u.unpark());
-//!     let cx = &mut Context::from_waker(&waker);
-//!
-//!     pin!(future);
-//!     loop {
-//!         match future.as_mut().poll(cx) {
-//!             Poll::Ready(t) => return t, // Done!
-//!             Poll::Pending => p.park(),  // Wait for an I/O event.
-//!         }
-//!     }
-//! }
-//!
-//! block_on(async {
-//!     println!("Hello world!");
-//!     future::yield_now().await;
-//!     println!("Hello again!");
-//! });
-//! ```
 
 use std::cell::RefCell;
 use std::collections::BTreeMap;

--- a/src/parking.rs
+++ b/src/parking.rs
@@ -21,13 +21,13 @@
 //!
 //! A simple `block_on()` that runs a single future and waits on I/O:
 //!
-//! ```
+//! ```no_run
 //! use std::future::Future;
 //! use std::task::{Context, Poll};
 //!
-//! use async_io::parking;
+//! use scipio::parking;
 //! use futures_lite::{future, pin};
-//! use waker_fn::waker_fn;
+//! use scipio::task::waker_fn;
 //!
 //! // Blocks on a future to complete, waiting on I/O when idle.
 //! fn block_on<T>(future: impl Future<Output = T>) -> T {
@@ -82,7 +82,7 @@ thread_local!(static LOCAL_REACTOR: Reactor = Reactor::new());
 /// # Examples
 ///
 /// ```
-/// use async_io::parking;
+/// use scipio::parking;
 ///
 /// let (p, u) = parking::pair();
 /// ```
@@ -106,7 +106,7 @@ impl Parker {
     /// # Examples
     ///
     /// ```
-    /// use async_io::parking::Parker;
+    /// use scipio::parking::Parker;
     ///
     /// let p = Parker::new();
     /// ```
@@ -125,8 +125,8 @@ impl Parker {
     ///
     /// # Examples
     ///
-    /// ```
-    /// use async_io::parking::Parker;
+    /// ```no_run
+    /// use scipio::parking::Parker;
     ///
     /// let p = Parker::new();
     /// let u = p.unparker();
@@ -150,7 +150,7 @@ impl Parker {
     /// # Examples
     ///
     /// ```
-    /// use async_io::parking::Parker;
+    /// use scipio::parking::Parker;
     /// use std::time::Duration;
     ///
     /// let p = Parker::new();
@@ -169,7 +169,7 @@ impl Parker {
     /// # Examples
     ///
     /// ```
-    /// use async_io::parking::Parker;
+    /// use scipio::parking::Parker;
     /// use std::time::{Duration, Instant};
     ///
     /// let p = Parker::new();
@@ -187,20 +187,16 @@ impl Parker {
     ///
     /// # Examples
     ///
-    /// ```
-    /// use async_io::parking::Parker;
-    /// use std::thread;
-    /// use std::time::Duration;
+    /// ```no_run
+    /// use scipio::parking::Parker;
     ///
     /// let p = Parker::new();
     /// let u = p.unparker();
     ///
-    /// thread::spawn(move || {
-    ///     thread::sleep(Duration::from_millis(500));
-    ///     u.unpark();
-    /// });
+    /// // Notify the parker.
+    /// u.unpark();
     ///
-    /// // Wakes up when `u.unpark()` notifies and then goes back into unnotified state.
+    /// // Wakes up immediately because the parker is notified.
     /// p.park();
     /// ```
     pub fn unpark(&self) {
@@ -213,8 +209,8 @@ impl Parker {
     ///
     /// # Examples
     ///
-    /// ```
-    /// use async_io::parking::Parker;
+    /// ```no_run
+    /// use scipio::parking::Parker;
     ///
     /// let p = Parker::new();
     /// let u = p.unparker();
@@ -259,20 +255,16 @@ impl Unparker {
     ///
     /// # Examples
     ///
-    /// ```
-    /// use async_io::parking::Parker;
-    /// use std::thread;
-    /// use std::time::Duration;
+    /// ```no_run
+    /// use scipio::parking::Parker;
     ///
     /// let p = Parker::new();
     /// let u = p.unparker();
     ///
-    /// thread::spawn(move || {
-    ///     thread::sleep(Duration::from_millis(500));
-    ///     u.unpark();
-    /// });
+    /// // Notify the parker.
+    /// u.unpark();
     ///
-    /// // Wakes up when `u.unpark()` notifies and then goes back into unnotified state.
+    /// // Wakes up immediately because the parker is notified.
     /// p.park();
     /// ```
     pub fn unpark(&self) {

--- a/src/pollable.rs
+++ b/src/pollable.rs
@@ -33,7 +33,7 @@ use crate::sys::{self, Source};
 /// Connect to a server and echo incoming messages back to the server:
 ///
 /// ```no_run
-/// use async_io::Async;
+/// use scipio::Async;
 /// use futures_lite::io;
 /// use std::net::TcpStream;
 ///
@@ -51,7 +51,7 @@ use crate::sys::{self, Source};
 /// [`Async::write_with_mut()`]:
 ///
 /// ```no_run
-/// use async_io::Async;
+/// use scipio::Async;
 /// use std::net::TcpListener;
 ///
 /// # futures_lite::future::block_on(async {
@@ -87,7 +87,7 @@ impl<T: AsRawFd> Async<T> {
     /// # Examples
     ///
     /// ```
-    /// use async_io::Async;
+    /// use scipio::Async;
     /// use std::net::{SocketAddr, TcpListener};
     ///
     /// # futures_lite::future::block_on(async {
@@ -115,7 +115,7 @@ impl<T> Async<T> {
     /// # Examples
     ///
     /// ```
-    /// use async_io::Async;
+    /// use scipio::Async;
     /// use std::net::TcpListener;
     ///
     /// # futures_lite::future::block_on(async {
@@ -132,7 +132,7 @@ impl<T> Async<T> {
     /// # Examples
     ///
     /// ```
-    /// use async_io::Async;
+    /// use scipio::Async;
     /// use std::net::TcpListener;
     ///
     /// # futures_lite::future::block_on(async {
@@ -149,7 +149,7 @@ impl<T> Async<T> {
     /// # Examples
     ///
     /// ```
-    /// use async_io::Async;
+    /// use scipio::Async;
     /// use std::net::TcpListener;
     ///
     /// # futures_lite::future::block_on(async {
@@ -169,7 +169,7 @@ impl<T> Async<T> {
     /// # Examples
     ///
     /// ```no_run
-    /// use async_io::Async;
+    /// use scipio::Async;
     /// use std::net::TcpListener;
     ///
     /// # futures_lite::future::block_on(async {
@@ -190,11 +190,11 @@ impl<T> Async<T> {
     /// # Examples
     ///
     /// ```
-    /// use async_io::Async;
+    /// use scipio::Async;
     /// use std::net::{TcpStream, ToSocketAddrs};
     ///
     /// # futures_lite::future::block_on(async {
-    /// let addr = "example.com:80".to_socket_addrs()?.next().unwrap();
+    /// let addr = "::80".to_socket_addrs()?.next().unwrap();
     /// let stream = Async::<TcpStream>::connect(addr).await?;
     ///
     /// // Wait until the stream is writable.
@@ -217,7 +217,7 @@ impl<T> Async<T> {
     /// # Examples
     ///
     /// ```no_run
-    /// use async_io::Async;
+    /// use scipio::Async;
     /// use std::net::TcpListener;
     ///
     /// # futures_lite::future::block_on(async {
@@ -250,7 +250,7 @@ impl<T> Async<T> {
     /// # Examples
     ///
     /// ```no_run
-    /// use async_io::Async;
+    /// use scipio::Async;
     /// use std::net::TcpListener;
     ///
     /// # futures_lite::future::block_on(async {
@@ -289,7 +289,7 @@ impl<T> Async<T> {
     /// # Examples
     ///
     /// ```no_run
-    /// use async_io::Async;
+    /// use scipio::Async;
     /// use std::net::UdpSocket;
     ///
     /// # futures_lite::future::block_on(async {
@@ -323,7 +323,7 @@ impl<T> Async<T> {
     /// # Examples
     ///
     /// ```no_run
-    /// use async_io::Async;
+    /// use scipio::Async;
     /// use std::net::UdpSocket;
     ///
     /// # futures_lite::future::block_on(async {

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -14,7 +14,10 @@
 //! All executors have some kind of queue that holds runnable tasks:
 //!
 //! ```
-//! let (sender, receiver) = crossbeam::channel::unbounded();
+//! # use std::sync::mpsc::sync_channel;
+//! #
+//! # // a queue of task to eventually execute
+//! # let (sender, receiver) = sync_channel(10);
 //! #
 //! # // A future that will get spawned.
 //! # let future = async { 1 + 2 };
@@ -23,13 +26,16 @@
 //! # let schedule = move |task| sender.send(task).unwrap();
 //! #
 //! # // Construct a task.
-//! # let (task, handle) = async_task::spawn(future, schedule, ());
+//! # let (task, handle) = scipio::task::spawn(future, schedule, ());
 //! ```
 //!
 //! A task is constructed using either [`spawn`] or [`spawn_local`]:
 //!
 //! ```
-//! # let (sender, receiver) = crossbeam::channel::unbounded();
+//! # use std::sync::mpsc::sync_channel;
+//! #
+//! # // a queue of task to eventually execute
+//! # let (sender, receiver) = sync_channel(10);
 //! #
 //! // A future that will be spawned.
 //! let future = async { 1 + 2 };
@@ -38,7 +44,7 @@
 //! let schedule = move |task| sender.send(task).unwrap();
 //!
 //! // Construct a task.
-//! let (task, handle) = async_task::spawn(future, schedule, ());
+//! let (task, handle) = scipio::task::spawn(future, schedule, ());
 //!
 //! // Push the task into the queue by invoking its schedule function.
 //! task.schedule();
@@ -55,7 +61,10 @@
 //! runnable tasks out of the queue and running each one in order:
 //!
 //! ```no_run
-//! # let (sender, receiver) = crossbeam::channel::unbounded();
+//! # use std::sync::mpsc::sync_channel;
+//! #
+//! # // a queue of task to eventually execute
+//! # let (sender, receiver) = sync_channel(10);
 //! #
 //! # // A future that will get spawned.
 //! # let future = async { 1 + 2 };
@@ -64,7 +73,7 @@
 //! # let schedule = move |task| sender.send(task).unwrap();
 //! #
 //! # // Construct a task.
-//! # let (task, handle) = async_task::spawn(future, schedule, ());
+//! # let (task, handle) = scipio::task::spawn(future, schedule, ());
 //! #
 //! # // Push the task into the queue by invoking its schedule function.
 //! # task.schedule();
@@ -104,7 +113,7 @@
 //! woken, the function gets called:
 //!
 //! ```
-//! let waker = async_task::waker_fn(|| println!("Wake!"));
+//! let waker = scipio::task::waker_fn(|| println!("Wake!"));
 //!
 //! // Prints "Wake!" twice.
 //! waker.wake_by_ref();

--- a/src/task/task.rs
+++ b/src/task/task.rs
@@ -38,7 +38,8 @@ use crate::task::JoinHandle;
 /// # Examples
 ///
 /// ```
-/// use crossbeam::channel;
+/// use scipio::task::spawn;
+/// use std::sync::mpsc::sync_channel;
 ///
 /// // The future inside the task.
 /// let future = async {
@@ -46,11 +47,11 @@ use crate::task::JoinHandle;
 /// };
 ///
 /// // If the task gets woken up, it will be sent into this channel.
-/// let (s, r) = channel::unbounded();
+/// let (s, r) = sync_channel(10);
 /// let schedule = move |task| s.send(task).unwrap();
 ///
 /// // Create a task with the future and the schedule function.
-/// let (task, handle) = async_task::spawn(future, schedule, ());
+/// let (task, handle) = spawn(future, schedule, ());
 /// ```
 pub fn spawn<F, R, S, T>(future: F, schedule: S, tag: T) -> (Task<T>, JoinHandle<R, T>)
 where
@@ -103,7 +104,8 @@ where
 /// # Examples
 ///
 /// ```
-/// use crossbeam::channel;
+/// use scipio::task::spawn_local;
+/// use std::sync::mpsc::sync_channel;
 ///
 /// // The future inside the task.
 /// let future = async {
@@ -111,11 +113,11 @@ where
 /// };
 ///
 /// // If the task gets woken up, it will be sent into this channel.
-/// let (s, r) = channel::unbounded();
+/// let (s, r) = sync_channel(10);
 /// let schedule = move |task| s.send(task).unwrap();
 ///
 /// // Create a task with the future and the schedule function.
-/// let (task, handle) = async_task::spawn_local(future, schedule, ());
+/// let (task, handle) = spawn_local(future, schedule, ());
 /// ```
 pub fn spawn_local<F, R, S, T>(future: F, schedule: S, tag: T) -> (Task<T>, JoinHandle<R, T>)
 where

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -15,19 +15,21 @@ use std::time::{Duration, Instant};
 ///
 /// # Examples
 ///
-/// Sleep for 1 second:
+/// Sleep for 100 milliseconds:
 ///
 /// ```
-/// use async_io::Timer;
+/// use scipio::{LocalExecutor,Timer};
 /// use std::time::Duration;
 ///
 /// async fn sleep(dur: Duration) {
 ///     Timer::new(dur).await;
 /// }
 ///
-/// # futures_lite::future::block_on(async {
-/// sleep(Duration::from_secs(1)).await;
-/// # });
+/// let ex = LocalExecutor::new(None).expect("failed to create local executor");
+///
+/// ex.run(async {
+///     sleep(Duration::from_millis(100)).await;
+/// });
 /// ```
 #[derive(Debug)]
 pub struct Timer {
@@ -46,12 +48,10 @@ impl Timer {
     /// # Examples
     ///
     /// ```
-    /// use async_io::Timer;
+    /// use scipio::Timer;
     /// use std::time::Duration;
     ///
-    /// # futures_lite::future::block_on(async {
-    /// Timer::new(Duration::from_secs(1)).await;
-    /// # });
+    /// Timer::new(Duration::from_millis(100));
     /// ```
     pub fn new(dur: Duration) -> Timer {
         Timer {
@@ -69,13 +69,11 @@ impl Timer {
     /// # Examples
     ///
     /// ```
-    /// use async_io::Timer;
+    /// use scipio::Timer;
     /// use std::time::Duration;
     ///
-    /// # futures_lite::future::block_on(async {
     /// let mut t = Timer::new(Duration::from_secs(1));
     /// t.reset(Duration::from_millis(100));
-    /// # });
     /// ```
     pub fn reset(&mut self, dur: Duration) {
         if let Some((id, _)) = self.id_and_waker.as_ref() {


### PR DESCRIPTION
### What does this PR do?

Cargo compiles and runs code snippets in code documentation when testing
code. This commit updates them so that they are valid and use the latest
APIs.

Because scipio is a TPC async framework, it is sometimes difficult to
demonstrate a feature in the documentation (for example, the `Parker`
object). In these cases, they are marked as `no_run`.

Some other code snippets were left as-is because they rely on APIs that
don't exist anymore. For example, `multitask` examples that rely on a
now removed `LocalExecutor::ticker`.

### Motivation

`cargo test` was failing and some of the documentation was out-of-date

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
[] The new code I am adding is formatted using `rustfmt`
