### PR TITLE
Improve timers further

### DIFF
--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1001,3 +1001,22 @@ fn task_optimized_for_throughput() {
         join!(first, second);
     });
 }
+
+#[test]
+fn test_detach() {
+    use crate::Timer;
+
+    let ex = LocalExecutor::new(None).expect("failed to create local executor");
+
+    ex.spawn(async {
+        loop {
+            //   println!("I'm a background task looping forever.");
+            Task::<()>::later().await;
+        }
+    })
+    .detach();
+
+    ex.run(async {
+        Timer::new(std::time::Duration::from_micros(100)).await;
+    });
+}

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -251,7 +251,7 @@ impl ExecutorQueues {
             default_executor: TaskQueueHandle::default(),
             executor_index: 1, // 0 is the default
             last_vruntime: 0,
-            preempt_timer_duration: Duration::from_secs(u64::MAX),
+            preempt_timer_duration: Duration::from_secs(1),
         }))
     }
 
@@ -260,11 +260,11 @@ impl ExecutorQueues {
             .active_executors
             .iter()
             .map(|tq| match tq.borrow().io_requirements.latency_req {
-                Latency::NotImportant => Duration::from_secs(u64::MAX),
+                Latency::NotImportant => Duration::from_secs(1),
                 Latency::Matters(d) => d,
             })
             .min()
-            .unwrap_or(Duration::from_secs(u64::MAX));
+            .unwrap_or(Duration::from_secs(1));
     }
     fn maybe_activate(&mut self, index: usize) {
         let queue = self
@@ -958,9 +958,6 @@ fn task_optimized_for_throughput() {
         let rust_capture_sucks = move || (first_started.clone(), second_status.clone());
         let clone_sucks = rust_capture_sucks.clone();
 
-        // Loop until need_preempt is set. It is set to 2ms, but because this is a test
-        // and can be running overcommited or in whichever shared infrastructure, we'll
-        // allow the timer to fire in up to 1s. If it didn't fire in 1s, that's broken.
         let first = local_ex
             .spawn_into(
                 async move {
@@ -973,7 +970,7 @@ fn task_optimized_for_throughput() {
                         if *(second_status.borrow()) {
                             panic!("I was preempted but should not have been");
                         }
-                        if start.elapsed().as_secs() > 1 {
+                        if start.elapsed().as_millis() > 200 {
                             break;
                         }
                         Task::<()>::yield_if_needed().await;

--- a/src/parking.rs
+++ b/src/parking.rs
@@ -373,11 +373,6 @@ impl Reactor {
         *ioreq = req;
     }
 
-    /// Notifies the thread blocked on the reactor.
-    pub(crate) fn notify(&self) {
-        self.sys.notify().expect("failed to notify reactor");
-    }
-
     pub(crate) fn alloc_dma_buffer(&self, size: usize) -> DmaBuffer {
         self.sys.alloc_dma_buffer(size)
     }
@@ -479,9 +474,6 @@ impl Reactor {
             let mut timers = self.timers.borrow_mut();
             self.process_timer_ops(&mut timers);
         }
-
-        // Notify that a timer has been inserted.
-        self.notify();
 
         id
     }

--- a/src/sys/uring.rs
+++ b/src/sys/uring.rs
@@ -310,24 +310,22 @@ impl SleepableRing {
             _ => panic!("Unexpected source type when linking rings"),
         }
 
-        if d.as_secs() != u64::MAX {
-            let op = UringOpDescriptor::Timeout(d.as_micros().try_into().unwrap());
-            source
-                .as_mut()
-                .update_source_type(SourceType::Timeout(true));
+        let op = UringOpDescriptor::Timeout(d.as_micros().try_into().unwrap());
+        source
+            .as_mut()
+            .update_source_type(SourceType::Timeout(true));
 
-            // This assumes SQEs will be processed in the order they are
-            // seen. Because remove does not do anything asynchronously
-            // and is processed inline there is no need to link sqes.
-            self.submission_queue().push_front(UringDescriptor {
-                args: op,
-                fd: -1,
-                user_data: src as _,
-            });
-            // No need to submit, the next ring enter will submit for us. Because
-            // we just flushed and we got put in front of the queue we should get a SQE.
-            // Still it would be nice to verify if we did.
-        }
+        // This assumes SQEs will be processed in the order they are
+        // seen. Because remove does not do anything asynchronously
+        // and is processed inline there is no need to link sqes.
+        self.submission_queue().push_front(UringDescriptor {
+            args: op,
+            fd: -1,
+            user_data: src as _,
+        });
+        // No need to submit, the next ring enter will submit for us. Because
+        // we just flushed and we got put in front of the queue we should get a SQE.
+        // Still it would be nice to verify if we did.
         Ok(())
     }
 

--- a/src/sys/uring.rs
+++ b/src/sys/uring.rs
@@ -664,10 +664,6 @@ impl Reactor {
         let cq = &lat_ring.ring.raw_mut().cq;
         (cq.khead, cq.ktail)
     }
-
-    pub(crate) fn notify(&self) -> io::Result<()> {
-        Ok(())
-    }
 }
 
 impl Drop for Reactor {


### PR DESCRIPTION
### What does this PR do?

This pull request improves the timers performance: before, we were conflating timers and the preempt timer, which caused timers to be re-registered with the i/o uring every time we polled.

Now we split those things in two. The timer information is used during sleep: contrary to the preempt timer, we can sleep if there is a timer pending but we make sure to wake up when it fires.

It was helpful that while investigating that we hit a bug in which tasks could run forever without yielding that informed some of the design decisions. That gets included in the PR too

### Checklist

[x] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
[x] The new code I am adding is formatted using `rustfmt`
