### PR TITLE
fix DmaFile.drop() fd != -1 file drop

### DIFF
--- a/src/dma_file.rs
+++ b/src/dma_file.rs
@@ -240,7 +240,7 @@ I will close it and turn a leak bug into a performance bug. Please investigate",
                 self.path,
                 self.as_raw_fd()
             );
-            drop(&self.file);
+            let _ = unsafe { libc::close(self.file.as_raw_fd()) };
         }
     }
 }


### PR DESCRIPTION
`std::mem::drop()` does nothing when drop references.
so that `drop(&self.file)` must be invalid.

The only way to close a file is to call a syscall with fd.

Other option could be using `ManualDrop<>`: https://stackoverflow.com/questions/41053542/forcing-the-order-in-which-struct-fields-are-dropped

Disclaimer
---

I didn't actually run it to test it. Sorry.