### PR TITLE
sqe: always fallback to allocation of a posix buffer

### DIFF
--- a/scipio/src/sys/uring.rs
+++ b/scipio/src/sys/uring.rs
@@ -344,7 +344,7 @@ impl SleepableRing {
                         user_data: link.as_ref().as_ptr() as *const Source as u64,
                         args: UringOpDescriptor::PollAdd(common_flags() | read_flags()),
                     };
-                    fill_sqe(&mut sqe, &op, |_| None);
+                    fill_sqe(&mut sqe, &op, |size| PosixDmaBuffer::new(size));
                 }
             }
             _ => panic!("Unexpected source type when linking rings"),
@@ -428,7 +428,7 @@ impl UringCommon for SleepableRing {
 
         if let Some(mut sqe) = self.ring.next_sqe() {
             let op = self.submission_queue.pop_front().unwrap();
-            fill_sqe(&mut sqe, &op, |_| None);
+            fill_sqe(&mut sqe, &op, |size| PosixDmaBuffer::new(size));
             return Some(());
         }
         None


### PR DESCRIPTION
We don't allocate a buffer right now, passing an empty closure
if we are not in the poll ring. That's because I/O only goes through
the poll ring.

However we'd like to relax those restrictions soon. In preparation
for that, everybody passes a buffer. Later, when we implement uring
buffers, the poll ring will be able to pass registered buffers.


### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
[x] The new code I am adding is formatted using `rustfmt`
