### PR TITLE
require specific versions of liburing

### DIFF
--- a/scipio/Cargo.toml
+++ b/scipio/Cargo.toml
@@ -18,8 +18,8 @@ concurrent-queue = "1.1.2"
 futures-lite = "0.1.9"
 libc = "0.2.73"
 socket2 = { version = "0.3.12", features = ["pair", "unix"] }
-iou = { git = "https://github.com/glommer/iou", branch = "master" }
-uring-sys = { git = "https://github.com/glommer/uring-sys", branch="master" }
+iou = { git = "https://github.com/glommer/iou", tag = "poll-ring-works" }
+uring-sys = { git = "https://github.com/glommer/uring-sys", tag= "poll-ring-works" }
 nix = "0.16.0"
 aligned_alloc = "0.1"
 bitmaps = "2.1.0"


### PR DESCRIPTION
Unfortunately liburing recently had a regression that
breaks the poll ring.

This is fixed upstream, but for now we will require specific
version of uring-sys (which in turn contains liburing) and iou (which
in turns uses uring-sys) to avoid seeing this breaking for everybody.

### What does this PR do?

unfucks everything for everybody.


