### PR TITLE
unshare the fs and file execution contexts

### DIFF
--- a/scipio/src/sys/uring.rs
+++ b/scipio/src/sys/uring.rs
@@ -501,6 +501,21 @@ macro_rules! queue_standard_request {
 
 impl Reactor {
     pub(crate) fn new() -> io::Result<Reactor> {
+        // Different threads have no business passing files around. Once you have
+        // a file descriptor you can do unsafe operations on it, and if some other
+        // thread happens to have the same fd, then this is no fun.
+        //
+        // In Seastar fds are passed around to the I/O Scheduler, but when the time
+        // come for us to do the same I would prefer to mediate that through other,
+        // safer interfaces like an Arc-like version of the DmaFile.
+        //
+        // We can't prohibit users from passing a file descriptor because at the end
+        // of the day that's just an integer, but we can call unshare() to make sure
+        // that threads of the same process do not have the same set of file descriptors.
+        //
+        // The damage is at least contained.
+        syscall!(unshare(libc::CLONE_FILES | libc::CLONE_FS))?;
+
         const MIN_MEMLOCK_LIMIT: u64 = 512 * 1024;
         let (memlock_limit, _) = Resource::MEMLOCK.get()?;
         if memlock_limit < MIN_MEMLOCK_LIMIT {


### PR DESCRIPTION
I have recently came across a quite puzzling scenario:
One of our new tests, fallback_drop_closes_the_file would fail at times.

In some of those times (but now always), some other tests that
are with us for longer would fail as well, and in quite inexplicable
manner.

Turns out the reason for that is that the test forces a close() which
is totally fine on a single threaded environment but the test infrastructure
itself will run in many threads (all in the same process).

By default, Linux threads in the same process share the file descriptor
table so one of the other tests at that point may have opened a file and
got the same fd that we are now trying to close (usually that was one
of the ring fds)

When were we lucky that was the poll ring in a non-file test, so no
other tests would fail because it would not be used in practice.

But if we were not lucky that was the active ring so we were suddenly
unable to dispatch requests through it. Nasty.

We are a thread per core library so users should have no business
passing file descriptors around. In Seastar fd passing exists in the
I/O Scheduler but when we get to that point I would like to have a
better, safer, more rustacean interface to allow that other than
passing fds, that can be declared Send + Sync.

Linux is flexible enough to allow us to choose which parts of the
execution context we want to share among threads of the same process as
flags to the clone system call. That is much harder to control because
it is deep inside the pthread implementation. However luckily some of those
flags can be cleared by the unshare() system call.

CLONE_FILES unshares the file descriptor table.
CLONE_FS unshares things like the current working directory and other
filesystem attributes.

After applying this  I have run `cargo test --lib` many times and it
always passes, consistently.

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
[] The new code I am adding is formatted using `rustfmt`
