### PR TITLE
add unit tests to basic file io APIs

### DIFF
--- a/scipio/src/dma_file.rs
+++ b/scipio/src/dma_file.rs
@@ -446,28 +446,268 @@ impl DmaFile {
     }
 }
 
+#[cfg(test)]
+fn make_test_directory(test_name: &str) -> PathBuf {
+    // Scipio currently only supports NVMe-backed volumes formatted with XFS or EXT4.
+    // We therefore can't use the system-provided tmpfs for our test so instead we let the user
+    // decide what directory scipio should use to perform integration tests.
+    // For more information regarding this limitation, see the README
+    match std::env::var("SCIPIO_TESTROOTDIR") {
+        Err(_) => {
+            eprintln!(
+                "Scipio currently only supports NVMe-backed volumes formatted with XFS \
+                or EXT4. To run io-related tests, please set SCIPIO_TESTROOTDIR to a NVMe-backed \
+                directory path in your environment."
+            );
+            panic!("missing SCIPIO_TESTROOTDIR environment variable")
+        }
+        Ok(path) => {
+            let mut dir = PathBuf::from(path);
+            std::assert!(dir.exists());
+
+            dir.push(test_name);
+            let _ = std::fs::remove_dir_all(&dir);
+            std::fs::create_dir_all(&dir).unwrap();
+            dir
+        }
+    }
+}
+
 #[test]
 fn fallback_drop_closes_the_file() {
-    use crate::executor::LocalExecutor;
-    use std::env;
-    use std::io::Error;
+    let path = make_test_directory("fallback_drop_closes_the_file");
 
-    let ex = LocalExecutor::new(None).unwrap();
-    {
-        let mut path = env::current_dir().unwrap();
-        path.push("testfile");
-        ex.run(async {
-            let fd;
-            {
-                let file = DmaFile::create(&path).await.expect("failed to create file");
-                fd = file.as_raw_fd();
-                std::fs::remove_file(&path).unwrap();
-            }
-            assert!(fd != -1);
-            let ret = unsafe { libc::close(fd) };
-            assert_eq!(ret, -1);
-            let err = Error::last_os_error().raw_os_error().unwrap();
-            assert_eq!(err, libc::EBADF);
-        });
-    }
+    test_executor!(async move {
+        let fd;
+        {
+            let file = DmaFile::create(path.join("testfile"))
+                .await
+                .expect("failed to create file");
+            fd = file.as_raw_fd();
+            std::fs::remove_file(path.join("testfile")).unwrap();
+        }
+        assert!(fd != -1);
+        let ret = unsafe { libc::close(fd) };
+        assert_eq!(ret, -1);
+        let err = std::io::Error::last_os_error().raw_os_error().unwrap();
+        assert_eq!(err, libc::EBADF);
+    });
+}
+
+#[test]
+fn file_create_close() {
+    let path = make_test_directory("io_file_create_close");
+
+    test_executor!(async move {
+        let mut new_file = DmaFile::create(path.join("testfile"))
+            .await
+            .expect("failed to create file");
+        new_file.close().await.expect("failed to close file");
+
+        std::assert!(path.join("testfile").exists());
+    });
+}
+
+#[test]
+fn file_open() {
+    let path = make_test_directory("file_open");
+
+    test_executor!(async move {
+        let mut new_file = DmaFile::create(path.join("testfile"))
+            .await
+            .expect("failed to create file");
+        new_file.close().await.expect("failed to close file");
+
+        let mut file = DmaFile::open(path.join("testfile"))
+            .await
+            .expect("failed to open file");
+        file.close().await.expect("failed to close file");
+
+        std::assert!(path.join("testfile").exists());
+    });
+}
+
+#[test]
+fn file_open_nonexistent() {
+    let path = make_test_directory("file_open_nonexistent");
+
+    test_executor!(async move {
+        DmaFile::open(path.join("testfile"))
+            .await
+            .expect_err("opened nonexistent file");
+        std::assert!(!path.join("testfile").exists());
+    });
+}
+
+#[test]
+fn file_rename() {
+    let root_path = make_test_directory("io_file_rename");
+
+    test_executor!(async move {
+        let mut new_file = DmaFile::create(root_path.join("testfile"))
+            .await
+            .expect("failed to create file");
+
+        new_file
+            .rename(root_path.join("testfile2"))
+            .await
+            .expect("failed to rename file");
+
+        std::assert!(!root_path.join("testfile").exists());
+        std::assert!(root_path.join("testfile2").exists());
+
+        new_file.close().await.expect("failed to close file");
+    });
+}
+
+#[test]
+fn file_rename_noop() {
+    let root_path = make_test_directory("file_rename_noop");
+
+    test_executor!(async move {
+        let mut new_file = DmaFile::create(root_path.join("testfile"))
+            .await
+            .expect("failed to create file");
+
+        new_file
+            .rename(root_path.join("testfile"))
+            .await
+            .expect("failed to rename file");
+        std::assert!(root_path.join("testfile").exists());
+
+        new_file.close().await.expect("failed to close file");
+    });
+}
+
+#[test]
+fn file_allocate() {
+    let root_path = make_test_directory("io_file_allocate");
+
+    test_executor!(async move {
+        let mut new_file = DmaFile::create(root_path.join("testfile"))
+            .await
+            .expect("failed to create file");
+
+        new_file.pre_allocate(4096).await.expect("fallocate failed");
+        std::assert_eq!(
+            new_file.file_size().await.unwrap(),
+            4096,
+            "file doesn't have expected size"
+        );
+        let metadata = std::fs::metadata(root_path.join("testfile")).unwrap();
+        std::assert_eq!(metadata.len(), 4096);
+
+        // should be noop
+        new_file.pre_allocate(2048).await.expect("fallocate failed");
+
+        std::assert_eq!(
+            new_file.file_size().await.unwrap(),
+            4096,
+            "file doesn't have expected size"
+        );
+        let metadata = std::fs::metadata(root_path.join("testfile")).unwrap();
+        std::assert_eq!(metadata.len(), 4096);
+
+        new_file.close().await.expect("failed to close file");
+    });
+}
+
+#[test]
+fn file_allocate_zero() {
+    let root_path = make_test_directory("io_file_allocate_zero");
+
+    test_executor!(async move {
+        let mut new_file = DmaFile::create(root_path.join("testfile"))
+            .await
+            .expect("failed to create file");
+        new_file
+            .pre_allocate(0)
+            .await
+            .expect_err("fallocate should fail with len == 0");
+
+        new_file.close().await.expect("failed to close file");
+    });
+}
+
+#[test]
+fn file_simple_readwrite() {
+    let root_path = make_test_directory("io_file_simple_readwrite");
+
+    test_executor!(async move {
+        let mut new_file = DmaFile::create(root_path.join("testfile"))
+            .await
+            .expect("failed to create file");
+
+        let buf = DmaBuffer::new(4096).expect("failed to allocate dma buffer");
+        buf.memset(42);
+        new_file.write_dma(&buf, 0).await.expect("failed to write");
+        new_file.close().await.expect("failed to close file");
+
+        let mut new_file = DmaFile::open(root_path.join("testfile"))
+            .await
+            .expect("failed to create file");
+        let read_buf = new_file.read_dma(0, 500).await.expect("failed to read");
+        std::assert_eq!(read_buf.len(), 500);
+        for i in 0..read_buf.len() {
+            std::assert_eq!(read_buf.as_bytes()[i], buf.as_bytes()[i]);
+        }
+
+        let read_buf = new_file
+            .read_dma_aligned(0, 4096)
+            .await
+            .expect("failed to read");
+        std::assert_eq!(read_buf.len(), 4096);
+        for i in 0..read_buf.len() {
+            std::assert_eq!(read_buf.as_bytes()[i], buf.as_bytes()[i]);
+        }
+
+        new_file.close().await.expect("failed to close file");
+    });
+}
+
+#[test]
+fn file_invalid_readonly_write() {
+    let root_path = make_test_directory("file_invalid_readonly_write");
+
+    let file = std::fs::File::create(root_path.join("testfile")).expect("failed to create file");
+    let mut perms = file
+        .metadata()
+        .expect("failed to fetch metadata")
+        .permissions();
+    perms.set_readonly(true);
+    file.set_permissions(perms)
+        .expect("failed to update file permissions");
+
+    test_executor!(async move {
+        let mut new_file = DmaFile::open(root_path.join("testfile"))
+            .await
+            .expect("open failed");
+        let buf = DmaBuffer::new(4096).expect("failed to allocate dma buffer");
+
+        new_file
+            .write_dma(&buf, 0)
+            .await
+            .expect_err("writes to read-only files should fail");
+        new_file
+            .pre_allocate(4096)
+            .await
+            .expect_err("pre allocating read-only files should fail");
+        new_file.close().await.expect("failed to close file");
+    });
+}
+
+#[test]
+fn file_empty_read() {
+    let root_path = make_test_directory("file_empty_read");
+
+    std::fs::File::create(root_path.join("testfile")).expect("failed to create file");
+
+    test_executor!(async move {
+        let mut new_file = DmaFile::open(root_path.join("testfile"))
+            .await
+            .expect("failed to open file");
+        let buf = new_file.read_dma(0, 512).await.expect("failed to read");
+        std::assert_eq!(buf.len(), 0);
+        new_file.close().await.expect("failed to close file");
+    });
 }

--- a/scipio/src/sys/posix_buffers.rs
+++ b/scipio/src/sys/posix_buffers.rs
@@ -58,6 +58,10 @@ impl PosixDmaBuffer {
     pub fn as_ptr(&self) -> *const u8 {
         unsafe { self.data.add(self.trim) }
     }
+
+    pub fn memset(&self, value: u8) {
+        unsafe { std::ptr::write_bytes(self.as_mut_ptr(), value, self.size) }
+    }
 }
 
 impl Drop for PosixDmaBuffer {


### PR DESCRIPTION
### What does this PR do?

Add unit test for all basic file APIs (create, open, close, rename,
allocate, read, write).
Scipio currently only supports NVMe-backed volumes formatted with XFS or
EXT4. We therefore can't use the system-provided tmpfs for our test so
instead we let the user decide what directory scipio should use to host
tests.

### Motivation

What inspired you to submit this pull request?

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
[] The new code I am adding is formatted using `rustfmt`
