### PR TITLE
transparent support for tmpfs file io

### DIFF
--- a/scipio/src/dma_file.rs
+++ b/scipio/src/dma_file.rs
@@ -306,7 +306,7 @@ impl DmaFile {
         }
 
         let mut f = enhance!(res, "Opening", Some(&path), None)?;
-        f.o_direct_alignment = 4096;
+        f.o_direct_alignment = 512;
         Ok(f)
     }
 

--- a/scipio/src/parking.rs
+++ b/scipio/src/parking.rs
@@ -37,7 +37,7 @@ use concurrent_queue::ConcurrentQueue;
 use futures_lite::*;
 
 use crate::sys;
-use crate::sys::{DmaBuffer, Source, SourceType};
+use crate::sys::{DmaBuffer, PollableStatus, Source, SourceType};
 use crate::IoRequirements;
 
 thread_local!(static LOCAL_REACTOR: Reactor = Reactor::new());
@@ -382,7 +382,7 @@ impl Reactor {
         raw: RawFd,
         buf: &DmaBuffer,
         pos: u64,
-        pollable: bool,
+        pollable: PollableStatus,
     ) -> Pin<Box<Source>> {
         let source = self.new_source(raw, SourceType::DmaWrite(pollable));
         self.sys.write_dma(&source.as_ref(), buf, pos);
@@ -394,7 +394,7 @@ impl Reactor {
         raw: RawFd,
         pos: u64,
         size: usize,
-        pollable: bool,
+        pollable: PollableStatus,
     ) -> Pin<Box<Source>> {
         let source = self.new_source(raw, SourceType::DmaRead(pollable, None));
         self.sys.read_dma(&source.as_ref(), pos, size);

--- a/scipio/src/parking.rs
+++ b/scipio/src/parking.rs
@@ -377,14 +377,26 @@ impl Reactor {
         self.sys.alloc_dma_buffer(size)
     }
 
-    pub(crate) fn write_dma(&self, raw: RawFd, buf: &DmaBuffer, pos: u64) -> Pin<Box<Source>> {
-        let source = self.new_source(raw, SourceType::DmaWrite);
+    pub(crate) fn write_dma(
+        &self,
+        raw: RawFd,
+        buf: &DmaBuffer,
+        pos: u64,
+        pollable: bool,
+    ) -> Pin<Box<Source>> {
+        let source = self.new_source(raw, SourceType::DmaWrite(pollable));
         self.sys.write_dma(&source.as_ref(), buf, pos);
         source
     }
 
-    pub(crate) fn read_dma<'a>(&self, raw: RawFd, pos: u64, size: usize) -> Pin<Box<Source>> {
-        let source = self.new_source(raw, SourceType::DmaRead(None));
+    pub(crate) fn read_dma<'a>(
+        &self,
+        raw: RawFd,
+        pos: u64,
+        size: usize,
+        pollable: bool,
+    ) -> Pin<Box<Source>> {
+        let source = self.new_source(raw, SourceType::DmaRead(pollable, None));
         self.sys.read_dma(&source.as_ref(), pos, size);
         source
     }

--- a/scipio/src/sys/mod.rs
+++ b/scipio/src/sys/mod.rs
@@ -98,8 +98,8 @@ pub type DmaBuffer = PosixDmaBuffer;
 
 #[derive(Debug)]
 pub(crate) enum SourceType {
-    DmaWrite,
-    DmaRead(Option<DmaBuffer>),
+    DmaWrite(bool),
+    DmaRead(bool, Option<DmaBuffer>),
     PollableFd,
     Open(CString),
     FdataSync,

--- a/scipio/src/sys/mod.rs
+++ b/scipio/src/sys/mod.rs
@@ -89,6 +89,7 @@ pub(crate) fn sync_open(path: &Path, flags: libc::c_int, mode: libc::c_int) -> i
 
 mod posix_buffers;
 mod uring;
+
 pub use self::posix_buffers::*;
 pub use self::uring::*;
 use crate::IoRequirements;
@@ -96,10 +97,16 @@ use crate::IoRequirements;
 /// A buffer that can be used with DmaFile.
 pub type DmaBuffer = PosixDmaBuffer;
 
+#[derive(Debug, Copy, Clone)]
+pub(crate) enum PollableStatus {
+    Pollable,
+    NonPollable,
+}
+
 #[derive(Debug)]
 pub(crate) enum SourceType {
-    DmaWrite(bool),
-    DmaRead(bool, Option<DmaBuffer>),
+    DmaWrite(PollableStatus),
+    DmaRead(PollableStatus, Option<DmaBuffer>),
     PollableFd,
     Open(CString),
     FdataSync,

--- a/scipio/src/sys/uring.rs
+++ b/scipio/src/sys/uring.rs
@@ -126,7 +126,11 @@ where
                 //sqe.prep_read_fixed(op.fd, buf.as_mut_bytes(), pos, slabidx);
                 sqe.prep_read(op.fd, buf.as_mut_bytes(), pos);
                 let source = &mut *(op.user_data as *mut Source);
-                source.source_type = SourceType::DmaRead(Some(buf));
+                if let SourceType::DmaRead(pollable, _) = &source.source_type {
+                    source.source_type = SourceType::DmaRead(*pollable, Some(buf));
+                } else {
+                    panic!("Expected DmaRead source type");
+                }
             }
 
             UringOpDescriptor::WriteFixed(ptr, len, pos, _) => {


### PR DESCRIPTION
### What does this PR do?

This PR adds support for file io on files that don't support `O_DIRECT`.

It uses a `SourceFd` union of `RawFd`s in the file APIs to indicate to
the Reactor whether a file supports poll operations on the `poll_ring`.
`SourceFd` is trivially convertible to a `RawFd`.

This detection is performed when a file is first created or opened.

For now we support two configurations:
* either the fd can be open with `O_DIRECT` and we assume it is pollable
* or it is not pollable at all and will use the `main_ring`

This excludes some categories of device like HDDs (compatible with
`O_DIRECT` but not with polling). For now (and most probably, ever) we
ignore this case.

Also, this PR changes the way we unit test file io in the following ways:

We now run the unit tests on both tmpfs and, optionally, on a user-provided
directory that supports poll mode io_uring interactions. If none is
provided via the `SCIPIO_TEST_POLLIO_ROOTDIR` environment variable, a
message is printed on stderr, but the tests don't fail.

I modified all tests to run twice and included a mechanism for them to
change their assertions depending on the current target directory. This
allows `file_allocate` to expect success for non `IO_DIRECT` files and
expect a failure otherwise.

I am not certain this is the right approach in practice though. It may be
simpler to just duplicate all tests.

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
[] The new code I am adding is formatted using `rustfmt`
