### PR TITLE
simplify capture of clone vars

### DIFF
--- a/scipio/src/lib.rs
+++ b/scipio/src/lib.rs
@@ -49,7 +49,6 @@ pub mod parking;
 mod sys;
 pub mod task;
 
-mod executor;
 #[cfg(test)]
 macro_rules! test_executor {
     ($( $fut:expr ),+ ) => {
@@ -125,9 +124,20 @@ macro_rules! make_shared_var_mut {
     }
 }
 
+#[cfg(test)]
+macro_rules! enclose {
+    ( ($( $x:ident ),*) $y:expr ) => {
+        {
+            $(let $x = $x.clone();)*
+            $y
+        }
+    };
+}
+
 mod async_collections;
 mod dma_file;
 mod error;
+mod executor;
 mod local_semaphore;
 mod multitask;
 mod networking;


### PR DESCRIPTION
Instead of doing 

```
let x = Rc<...>(...);
let f = || x.clone();
let f2 = f.clone()
```

It can be done with anonymous function like this:

```
let second = local_ex
            .spawn_into(
                (|f: Rc<RefCell<bool>>, s: Rc<RefCell<bool>>| {
                    async move {
                       ...
                    }
                })(first_started.clone(), second_status.clone()),
                tq2,
            )
            .unwrap();

```

I am not happy Rust can't derive type information for (f, s) himself so it's required to be stated it explicitly as in `|f: Rc<RefCell<bool>>, s: Rc<RefCell<bool>>|` instead of `|f, s|`.

However, there is a popular macro `enclose!` that does the job.

```
  enclose! { (first_started, second_status)
                    async move {
                  ...
                    }
}
```