### PR TITLE
Extend the documentation of write_dma and read_dma_aligned

### DIFF
--- a/scipio/src/dma_file.rs
+++ b/scipio/src/dma_file.rs
@@ -316,14 +316,19 @@ impl DmaFile {
 
     /// Writes the buffer in buf to a specific position in the file.
     ///
-    /// It is expected that the buffer is properly aligned for Direct I/O.
-    /// In most platforms that means 512 bytes.
+    /// It is expected that the buffer and the position be properly aligned
+    /// for Direct I/O. In most platforms that means 4096 bytes. There is no
+    /// write_dma_aligned, since a non aligned write would require a
+    /// read-modify-write.
     pub async fn write_dma(&self, buf: &DmaBuffer, pos: u64) -> Result<usize> {
         let source = Reactor::get().write_dma(self.as_raw_fd(), buf, pos, self.pollable);
         enhanced_try!(source.collect_rw().await, "Writing", self)
     }
 
     /// Reads from a specific position in the file and returns the buffer.
+    ///
+    /// The position must be aligned to for Direct I/O. In most platforms
+    /// that means 512 bytes.
     pub async fn read_dma_aligned(&self, pos: u64, size: usize) -> Result<DmaBuffer> {
         let mut source = Reactor::get().read_dma(self.as_raw_fd(), pos, size, self.pollable);
         let read_size = enhanced_try!(source.collect_rw().await, "Reading", self)?;


### PR DESCRIPTION
They now mention that pos has to be aligned.
