### PR TITLE
Dma file tests

### DIFF
--- a/scipio/src/dma_file.rs
+++ b/scipio/src/dma_file.rs
@@ -461,308 +461,312 @@ impl DmaFile {
 }
 
 #[cfg(test)]
-enum TestDirectoryKind {
-    TempFs,
-    StorageMedia,
-}
+mod test {
+    use super::*;
 
-#[cfg(test)]
-fn make_test_directories(test_name: &str) -> std::vec::Vec<(PathBuf, TestDirectoryKind)> {
-    let mut vec: std::vec::Vec<(PathBuf, TestDirectoryKind)> = Vec::new();
+    enum TestDirectoryKind {
+        TempFs,
+        StorageMedia,
+    }
 
-    // Scipio currently only supports NVMe-backed volumes formatted with XFS or EXT4.
-    // We therefore let the user decide what directory scipio should use to host the unit tests in.
-    // For more information regarding this limitation, see the README
-    match std::env::var("SCIPIO_TEST_POLLIO_ROOTDIR") {
-        Err(_) => {
-            eprintln!(
-                "Scipio currently only supports NVMe-backed volumes formatted with XFS \
-                or EXT4. To run poll io-related tests, please set SCIPIO_TEST_POLLIO_ROOTDIR to a \
-                NVMe-backed directory path in your environment.\nPoll io tests will not run."
-            );
+    #[cfg(test)]
+    fn make_test_directories(test_name: &str) -> std::vec::Vec<(PathBuf, TestDirectoryKind)> {
+        let mut vec: std::vec::Vec<(PathBuf, TestDirectoryKind)> = Vec::new();
+
+        // Scipio currently only supports NVMe-backed volumes formatted with XFS or EXT4.
+        // We therefore let the user decide what directory scipio should use to host the unit tests in.
+        // For more information regarding this limitation, see the README
+        match std::env::var("SCIPIO_TEST_POLLIO_ROOTDIR") {
+            Err(_) => {
+                eprintln!(
+                    "Scipio currently only supports NVMe-backed volumes formatted with XFS \
+                    or EXT4. To run poll io-related tests, please set SCIPIO_TEST_POLLIO_ROOTDIR to a \
+                    NVMe-backed directory path in your environment.\nPoll io tests will not run."
+                );
+            }
+            Ok(path) => {
+                let mut dir = PathBuf::from(path);
+                std::assert!(dir.exists());
+
+                dir.push(test_name);
+                let _ = std::fs::remove_dir_all(&dir);
+                std::fs::create_dir_all(&dir).unwrap();
+                vec.push((dir, TestDirectoryKind::StorageMedia))
+            }
+        };
+
+        let mut dir = std::env::temp_dir();
+        dir.push(test_name);
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        vec.push((dir, TestDirectoryKind::TempFs));
+        return vec;
+    }
+
+    #[test]
+    fn fallback_drop_closes_the_file() {
+        let paths = make_test_directories("fallback_drop_closes_the_file");
+
+        for (path, _) in paths {
+            test_executor!(async move {
+                let fd;
+                {
+                    let file = DmaFile::create(path.join("testfile"))
+                        .await
+                        .expect("failed to create file");
+                    fd = file.as_raw_fd();
+                    std::fs::remove_file(path.join("testfile")).unwrap();
+                }
+                assert!(fd != -1);
+                let ret = unsafe { libc::close(fd) };
+                assert_eq!(ret, -1);
+                let err = std::io::Error::last_os_error().raw_os_error().unwrap();
+                assert_eq!(err, libc::EBADF);
+            });
         }
-        Ok(path) => {
-            let mut dir = PathBuf::from(path);
-            std::assert!(dir.exists());
+    }
 
-            dir.push(test_name);
-            let _ = std::fs::remove_dir_all(&dir);
-            std::fs::create_dir_all(&dir).unwrap();
-            vec.push((dir, TestDirectoryKind::StorageMedia))
-        }
-    };
+    #[test]
+    fn file_create_close() {
+        let paths = make_test_directories("io_file_create_close");
 
-    let mut dir = std::env::temp_dir();
-    dir.push(test_name);
-    let _ = std::fs::remove_dir_all(&dir);
-    std::fs::create_dir_all(&dir).unwrap();
-    vec.push((dir, TestDirectoryKind::TempFs));
-    return vec;
-}
-
-#[test]
-fn fallback_drop_closes_the_file() {
-    let paths = make_test_directories("fallback_drop_closes_the_file");
-
-    for (path, _) in paths {
-        test_executor!(async move {
-            let fd;
-            {
-                let file = DmaFile::create(path.join("testfile"))
+        for (path, _) in paths {
+            test_executor!(async move {
+                let mut new_file = DmaFile::create(path.join("testfile"))
                     .await
                     .expect("failed to create file");
-                fd = file.as_raw_fd();
-                std::fs::remove_file(path.join("testfile")).unwrap();
-            }
-            assert!(fd != -1);
-            let ret = unsafe { libc::close(fd) };
-            assert_eq!(ret, -1);
-            let err = std::io::Error::last_os_error().raw_os_error().unwrap();
-            assert_eq!(err, libc::EBADF);
-        });
+                new_file.close().await.expect("failed to close file");
+
+                std::assert!(path.join("testfile").exists());
+            });
+        }
     }
-}
 
-#[test]
-fn file_create_close() {
-    let paths = make_test_directories("io_file_create_close");
+    #[test]
+    fn file_open() {
+        let paths = make_test_directories("file_open");
 
-    for (path, _) in paths {
-        test_executor!(async move {
-            let mut new_file = DmaFile::create(path.join("testfile"))
-                .await
-                .expect("failed to create file");
-            new_file.close().await.expect("failed to close file");
+        for (path, _) in paths {
+            test_executor!(async move {
+                let mut new_file = DmaFile::create(path.join("testfile"))
+                    .await
+                    .expect("failed to create file");
+                new_file.close().await.expect("failed to close file");
 
-            std::assert!(path.join("testfile").exists());
-        });
+                let mut file = DmaFile::open(path.join("testfile"))
+                    .await
+                    .expect("failed to open file");
+                file.close().await.expect("failed to close file");
+
+                std::assert!(path.join("testfile").exists());
+            });
+        }
     }
-}
 
-#[test]
-fn file_open() {
-    let paths = make_test_directories("file_open");
+    #[test]
+    fn file_open_nonexistent() {
+        let paths = make_test_directories("file_open_nonexistent");
 
-    for (path, _) in paths {
-        test_executor!(async move {
-            let mut new_file = DmaFile::create(path.join("testfile"))
-                .await
-                .expect("failed to create file");
-            new_file.close().await.expect("failed to close file");
-
-            let mut file = DmaFile::open(path.join("testfile"))
-                .await
-                .expect("failed to open file");
-            file.close().await.expect("failed to close file");
-
-            std::assert!(path.join("testfile").exists());
-        });
+        for (path, _) in paths {
+            test_executor!(async move {
+                DmaFile::open(path.join("testfile"))
+                    .await
+                    .expect_err("opened nonexistent file");
+                std::assert!(!path.join("testfile").exists());
+            });
+        }
     }
-}
 
-#[test]
-fn file_open_nonexistent() {
-    let paths = make_test_directories("file_open_nonexistent");
+    #[test]
+    fn file_rename() {
+        let paths = make_test_directories("io_file_rename");
 
-    for (path, _) in paths {
-        test_executor!(async move {
-            DmaFile::open(path.join("testfile"))
-                .await
-                .expect_err("opened nonexistent file");
-            std::assert!(!path.join("testfile").exists());
-        });
+        for (path, _) in paths {
+            test_executor!(async move {
+                let mut new_file = DmaFile::create(path.join("testfile"))
+                    .await
+                    .expect("failed to create file");
+
+                new_file
+                    .rename(path.join("testfile2"))
+                    .await
+                    .expect("failed to rename file");
+
+                std::assert!(!path.join("testfile").exists());
+                std::assert!(path.join("testfile2").exists());
+
+                new_file.close().await.expect("failed to close file");
+            });
+        }
     }
-}
 
-#[test]
-fn file_rename() {
-    let paths = make_test_directories("io_file_rename");
+    #[test]
+    fn file_rename_noop() {
+        let paths = make_test_directories("file_rename_noop");
 
-    for (path, _) in paths {
-        test_executor!(async move {
-            let mut new_file = DmaFile::create(path.join("testfile"))
-                .await
-                .expect("failed to create file");
+        for (path, _) in paths {
+            test_executor!(async move {
+                let mut new_file = DmaFile::create(path.join("testfile"))
+                    .await
+                    .expect("failed to create file");
 
-            new_file
-                .rename(path.join("testfile2"))
-                .await
-                .expect("failed to rename file");
+                new_file
+                    .rename(path.join("testfile"))
+                    .await
+                    .expect("failed to rename file");
+                std::assert!(path.join("testfile").exists());
 
-            std::assert!(!path.join("testfile").exists());
-            std::assert!(path.join("testfile2").exists());
-
-            new_file.close().await.expect("failed to close file");
-        });
+                new_file.close().await.expect("failed to close file");
+            });
+        }
     }
-}
 
-#[test]
-fn file_rename_noop() {
-    let paths = make_test_directories("file_rename_noop");
+    #[test]
+    fn file_allocatfile_allocatee() {
+        let paths = make_test_directories("io_file_allocate");
 
-    for (path, _) in paths {
-        test_executor!(async move {
-            let mut new_file = DmaFile::create(path.join("testfile"))
-                .await
-                .expect("failed to create file");
+        for (path, kind) in paths {
+            test_executor!(async move {
+                let mut new_file = DmaFile::create(path.join("testfile"))
+                    .await
+                    .expect("failed to create file");
 
-            new_file
-                .rename(path.join("testfile"))
-                .await
-                .expect("failed to rename file");
-            std::assert!(path.join("testfile").exists());
+                let res = new_file.pre_allocate(4096).await;
+                if let TestDirectoryKind::TempFs = kind {
+                    res.expect_err("fallocate should error on tmpfs");
+                    return;
+                }
+                res.expect("fallocate failed");
 
-            new_file.close().await.expect("failed to close file");
-        });
+                std::assert_eq!(
+                    new_file.file_size().await.unwrap(),
+                    4096,
+                    "file doesn't have expected size"
+                );
+                let metadata = std::fs::metadata(path.join("testfile")).unwrap();
+                std::assert_eq!(metadata.len(), 4096);
+
+                // should be noop
+                new_file.pre_allocate(2048).await.expect("fallocate failed");
+
+                std::assert_eq!(
+                    new_file.file_size().await.unwrap(),
+                    4096,
+                    "file doesn't have expected size"
+                );
+                let metadata = std::fs::metadata(path.join("testfile")).unwrap();
+                std::assert_eq!(metadata.len(), 4096);
+
+                new_file.close().await.expect("failed to close file");
+            });
+        }
     }
-}
 
-#[test]
-fn file_allocatfile_allocatee() {
-    let paths = make_test_directories("io_file_allocate");
+    #[test]
+    fn file_allocate_zero() {
+        let paths = make_test_directories("io_file_allocate_zero");
 
-    for (path, kind) in paths {
-        test_executor!(async move {
-            let mut new_file = DmaFile::create(path.join("testfile"))
-                .await
-                .expect("failed to create file");
+        for (path, _) in paths {
+            test_executor!(async move {
+                let mut new_file = DmaFile::create(path.join("testfile"))
+                    .await
+                    .expect("failed to create file");
+                new_file
+                    .pre_allocate(0)
+                    .await
+                    .expect_err("fallocate should fail with len == 0");
 
-            let res = new_file.pre_allocate(4096).await;
-            if let TestDirectoryKind::TempFs = kind {
-                res.expect_err("fallocate should error on tmpfs");
-                return;
-            }
-            res.expect("fallocate failed");
-
-            std::assert_eq!(
-                new_file.file_size().await.unwrap(),
-                4096,
-                "file doesn't have expected size"
-            );
-            let metadata = std::fs::metadata(path.join("testfile")).unwrap();
-            std::assert_eq!(metadata.len(), 4096);
-
-            // should be noop
-            new_file.pre_allocate(2048).await.expect("fallocate failed");
-
-            std::assert_eq!(
-                new_file.file_size().await.unwrap(),
-                4096,
-                "file doesn't have expected size"
-            );
-            let metadata = std::fs::metadata(path.join("testfile")).unwrap();
-            std::assert_eq!(metadata.len(), 4096);
-
-            new_file.close().await.expect("failed to close file");
-        });
+                new_file.close().await.expect("failed to close file");
+            });
+        }
     }
-}
 
-#[test]
-fn file_allocate_zero() {
-    let paths = make_test_directories("io_file_allocate_zero");
+    #[test]
+    fn file_simple_readwrite() {
+        let paths = make_test_directories("io_file_simple_readwrite");
 
-    for (path, _) in paths {
-        test_executor!(async move {
-            let mut new_file = DmaFile::create(path.join("testfile"))
-                .await
-                .expect("failed to create file");
-            new_file
-                .pre_allocate(0)
-                .await
-                .expect_err("fallocate should fail with len == 0");
+        for (path, _) in paths {
+            test_executor!(async move {
+                let mut new_file = DmaFile::create(path.join("testfile"))
+                    .await
+                    .expect("failed to create file");
 
-            new_file.close().await.expect("failed to close file");
-        });
+                let buf = DmaBuffer::new(4096).expect("failed to allocate dma buffer");
+                buf.memset(42);
+                new_file.write_dma(&buf, 0).await.expect("failed to write");
+                new_file.close().await.expect("failed to close file");
+
+                let mut new_file = DmaFile::open(path.join("testfile"))
+                    .await
+                    .expect("failed to create file");
+                let read_buf = new_file.read_dma(0, 500).await.expect("failed to read");
+                std::assert_eq!(read_buf.len(), 500);
+                for i in 0..read_buf.len() {
+                    std::assert_eq!(read_buf.as_bytes()[i], buf.as_bytes()[i]);
+                }
+
+                let read_buf = new_file
+                    .read_dma_aligned(0, 4096)
+                    .await
+                    .expect("failed to read");
+                std::assert_eq!(read_buf.len(), 4096);
+                for i in 0..read_buf.len() {
+                    std::assert_eq!(read_buf.as_bytes()[i], buf.as_bytes()[i]);
+                }
+
+                new_file.close().await.expect("failed to close file");
+            });
+        }
     }
-}
 
-#[test]
-fn file_simple_readwrite() {
-    let paths = make_test_directories("io_file_simple_readwrite");
+    #[test]
+    fn file_invalid_readonly_write() {
+        let paths = make_test_directories("file_invalid_readonly_write");
 
-    for (path, _) in paths {
-        test_executor!(async move {
-            let mut new_file = DmaFile::create(path.join("testfile"))
-                .await
-                .expect("failed to create file");
+        for (path, _) in paths {
+            let file = std::fs::File::create(path.join("testfile")).expect("failed to create file");
+            let mut perms = file
+                .metadata()
+                .expect("failed to fetch metadata")
+                .permissions();
+            perms.set_readonly(true);
+            file.set_permissions(perms)
+                .expect("failed to update file permissions");
 
-            let buf = DmaBuffer::new(4096).expect("failed to allocate dma buffer");
-            buf.memset(42);
-            new_file.write_dma(&buf, 0).await.expect("failed to write");
-            new_file.close().await.expect("failed to close file");
+            test_executor!(async move {
+                let mut new_file = DmaFile::open(path.join("testfile"))
+                    .await
+                    .expect("open failed");
+                let buf = DmaBuffer::new(4096).expect("failed to allocate dma buffer");
 
-            let mut new_file = DmaFile::open(path.join("testfile"))
-                .await
-                .expect("failed to create file");
-            let read_buf = new_file.read_dma(0, 500).await.expect("failed to read");
-            std::assert_eq!(read_buf.len(), 500);
-            for i in 0..read_buf.len() {
-                std::assert_eq!(read_buf.as_bytes()[i], buf.as_bytes()[i]);
-            }
-
-            let read_buf = new_file
-                .read_dma_aligned(0, 4096)
-                .await
-                .expect("failed to read");
-            std::assert_eq!(read_buf.len(), 4096);
-            for i in 0..read_buf.len() {
-                std::assert_eq!(read_buf.as_bytes()[i], buf.as_bytes()[i]);
-            }
-
-            new_file.close().await.expect("failed to close file");
-        });
+                new_file
+                    .write_dma(&buf, 0)
+                    .await
+                    .expect_err("writes to read-only files should fail");
+                new_file
+                    .pre_allocate(4096)
+                    .await
+                    .expect_err("pre allocating read-only files should fail");
+                new_file.close().await.expect("failed to close file");
+            });
+        }
     }
-}
 
-#[test]
-fn file_invalid_readonly_write() {
-    let paths = make_test_directories("file_invalid_readonly_write");
+    #[test]
+    fn file_empty_read() {
+        let paths = make_test_directories("file_empty_read");
 
-    for (path, _) in paths {
-        let file = std::fs::File::create(path.join("testfile")).expect("failed to create file");
-        let mut perms = file
-            .metadata()
-            .expect("failed to fetch metadata")
-            .permissions();
-        perms.set_readonly(true);
-        file.set_permissions(perms)
-            .expect("failed to update file permissions");
+        for (path, _) in paths {
+            std::fs::File::create(path.join("testfile")).expect("failed to create file");
 
-        test_executor!(async move {
-            let mut new_file = DmaFile::open(path.join("testfile"))
-                .await
-                .expect("open failed");
-            let buf = DmaBuffer::new(4096).expect("failed to allocate dma buffer");
-
-            new_file
-                .write_dma(&buf, 0)
-                .await
-                .expect_err("writes to read-only files should fail");
-            new_file
-                .pre_allocate(4096)
-                .await
-                .expect_err("pre allocating read-only files should fail");
-            new_file.close().await.expect("failed to close file");
-        });
-    }
-}
-
-#[test]
-fn file_empty_read() {
-    let paths = make_test_directories("file_empty_read");
-
-    for (path, _) in paths {
-        std::fs::File::create(path.join("testfile")).expect("failed to create file");
-
-        test_executor!(async move {
-            let mut new_file = DmaFile::open(path.join("testfile"))
-                .await
-                .expect("failed to open file");
-            let buf = new_file.read_dma(0, 512).await.expect("failed to read");
-            std::assert_eq!(buf.len(), 0);
-            new_file.close().await.expect("failed to close file");
-        });
+            test_executor!(async move {
+                let mut new_file = DmaFile::open(path.join("testfile"))
+                    .await
+                    .expect("failed to open file");
+                let buf = new_file.read_dma(0, 512).await.expect("failed to read");
+                std::assert_eq!(buf.len(), 0);
+                new_file.close().await.expect("failed to close file");
+            });
+        }
     }
 }


### PR DESCRIPTION
### What does this PR do?

Cleans up the test directory that was crated for the test

### Motivation

Right now we delete the directory before starting the test, but leave the files be when the test ends.
It's a better practice to cleanup after ourselves.

### Related issues

Before we do that, let's move these tests to the `mod test` pattern that we have been using in other files

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
[x] The new code I am adding is formatted using `rustfmt`
