### PR TITLE
More self documenting types; LocalExecutor configuration

### DIFF
--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -25,7 +25,8 @@ async fn server(conns: usize) {
     // necessarily spawn all executors at once running symmetrical code.
     let client_handle = LocalExecutorBuilder::new()
         .pin_to_cpu(2)
-        .spawn("client", move || async move {
+        .name(String::from("client"))
+        .spawn(move || async move {
             client(conns).await;
         })
         .unwrap();
@@ -82,7 +83,7 @@ fn main() -> Result<()> {
     // system configuration and most modern systems will balance it, but that it is
     // still common enough that it is worth excluding it in this benchmark
     let builder = LocalExecutorBuilder::new().pin_to_cpu(1);
-    let server_handle = builder.spawn("server", || async move {
+    let server_handle = builder.name(String::from("server")).spawn(|| async move {
         // If you try `top` during the execution of the first batch, you
         // will see that the CPUs should not be at 100%. A single connection will
         // not be enough to extract all the performance available in the cores.

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -25,7 +25,7 @@ async fn server(conns: usize) {
     // necessarily spawn all executors at once running symmetrical code.
     let client_handle = LocalExecutorBuilder::new()
         .pin_to_cpu(2)
-        .spawn_thread("client", move || async move {
+        .spawn("client", move || async move {
             client(conns).await;
         })
         .unwrap();
@@ -82,7 +82,7 @@ fn main() -> Result<()> {
     // system configuration and most modern systems will balance it, but that it is
     // still common enough that it is worth excluding it in this benchmark
     let builder = LocalExecutorBuilder::new().pin_to_cpu(1);
-    let server_handle = builder.spawn_thread("server", || async move {
+    let server_handle = builder.spawn("server", || async move {
         // If you try `top` during the execution of the first batch, you
         // will see that the CPUs should not be at 100%. A single connection will
         // not be enough to extract all the performance available in the cores.

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -25,7 +25,7 @@ async fn server(conns: usize) {
     // necessarily spawn all executors at once running symmetrical code.
     let client_handle = LocalExecutorBuilder::new()
         .pin_to_cpu(2)
-        .name(String::from("client"))
+        .name("client")
         .spawn(move || async move {
             client(conns).await;
         })
@@ -83,7 +83,7 @@ fn main() -> Result<()> {
     // system configuration and most modern systems will balance it, but that it is
     // still common enough that it is worth excluding it in this benchmark
     let builder = LocalExecutorBuilder::new().pin_to_cpu(1);
-    let server_handle = builder.name(String::from("server")).spawn(|| async move {
+    let server_handle = builder.name("server").spawn(|| async move {
         // If you try `top` during the execution of the first batch, you
         // will see that the CPUs should not be at 100%. A single connection will
         // not be enough to extract all the performance available in the cores.

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -4,7 +4,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
 //
 use futures::future::join_all;
-use scipio::{Local, LocalExecutor};
+use scipio::{Local, LocalExecutor, LocalExecutorBuilder};
 use std::io::Result;
 
 async fn hello() {
@@ -23,7 +23,7 @@ fn main() -> Result<()> {
     // There are two ways to create an executor, demonstrated in this example.
     //
     // We can create it in the current thread, and run it separately later...
-    let ex = LocalExecutor::new(Some(0))?;
+    let ex = LocalExecutorBuilder::new().pin_to_cpu(0).spawn()?;
 
     // Or we can spawn a new thread with an executor inside.
     let handle = LocalExecutor::spawn_executor("hello", Some(1), || async move {

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -23,11 +23,11 @@ fn main() -> Result<()> {
     // There are two ways to create an executor, demonstrated in this example.
     //
     // We can create it in the current thread, and run it separately later...
-    let ex = LocalExecutorBuilder::new().pin_to_cpu(0).spawn()?;
+    let ex = LocalExecutorBuilder::new().pin_to_cpu(0).make()?;
 
     // Or we can spawn a new thread with an executor inside.
     let builder = LocalExecutorBuilder::new().pin_to_cpu(1);
-    let handle = builder.spawn_thread("hello", || async move {
+    let handle = builder.spawn("hello", || async move {
         hello().await;
     })?;
 

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -27,7 +27,7 @@ fn main() -> Result<()> {
 
     // Or we can spawn a new thread with an executor inside.
     let builder = LocalExecutorBuilder::new().pin_to_cpu(1);
-    let handle = builder.name(String::from("hello")).spawn(|| async move {
+    let handle = builder.name("hello").spawn(|| async move {
         hello().await;
     })?;
 

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -4,7 +4,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
 //
 use futures::future::join_all;
-use scipio::{Local, LocalExecutor, LocalExecutorBuilder};
+use scipio::{Local, LocalExecutorBuilder};
 use std::io::Result;
 
 async fn hello() {
@@ -26,7 +26,8 @@ fn main() -> Result<()> {
     let ex = LocalExecutorBuilder::new().pin_to_cpu(0).spawn()?;
 
     // Or we can spawn a new thread with an executor inside.
-    let handle = LocalExecutor::spawn_executor("hello", Some(1), || async move {
+    let builder = LocalExecutorBuilder::new().pin_to_cpu(1);
+    let handle = builder.spawn_thread("hello", || async move {
         hello().await;
     })?;
 

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -27,7 +27,7 @@ fn main() -> Result<()> {
 
     // Or we can spawn a new thread with an executor inside.
     let builder = LocalExecutorBuilder::new().pin_to_cpu(1);
-    let handle = builder.spawn("hello", || async move {
+    let handle = builder.name(String::from("hello")).spawn(|| async move {
         hello().await;
     })?;
 

--- a/examples/ping_pong.rs
+++ b/examples/ping_pong.rs
@@ -8,7 +8,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 fn main() {
-    let ex = LocalExecutor::spawn_default();
+    let ex = LocalExecutor::make_default();
     let left = Rc::new(RefCell::new(false));
     let right = Rc::new(RefCell::new(false));
 

--- a/examples/ping_pong.rs
+++ b/examples/ping_pong.rs
@@ -8,7 +8,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 fn main() {
-    let ex = LocalExecutor::new(None).unwrap();
+    let ex = LocalExecutor::spawn_default();
     let left = Rc::new(RefCell::new(false));
     let right = Rc::new(RefCell::new(false));
 

--- a/scipio/src/collections/dequeue.rs
+++ b/scipio/src/collections/dequeue.rs
@@ -129,7 +129,7 @@ impl<T> Deque<T> {
     ///
     /// let ad : Deque<usize> = Deque::with_capacity(10);
     ///
-    /// let ex = LocalExecutor::new(None).unwrap();
+    /// let ex = LocalExecutor::spawn_default();
     /// ex.run(async move {
     ///     ad.push_front(1);
     ///     ad.push_front(2);
@@ -156,7 +156,7 @@ impl<T> Deque<T> {
     ///
     /// let ad : Deque<usize> = Deque::with_capacity(10);
     ///
-    /// let ex = LocalExecutor::new(None).unwrap();
+    /// let ex = LocalExecutor::spawn_default();
     /// ex.run(async move {
     ///     ad.push_front(1);
     ///     ad.push_front(2);

--- a/scipio/src/collections/dequeue.rs
+++ b/scipio/src/collections/dequeue.rs
@@ -129,7 +129,7 @@ impl<T> Deque<T> {
     ///
     /// let ad : Deque<usize> = Deque::with_capacity(10);
     ///
-    /// let ex = LocalExecutor::spawn_default();
+    /// let ex = LocalExecutor::make_default();
     /// ex.run(async move {
     ///     ad.push_front(1);
     ///     ad.push_front(2);
@@ -156,7 +156,7 @@ impl<T> Deque<T> {
     ///
     /// let ad : Deque<usize> = Deque::with_capacity(10);
     ///
-    /// let ex = LocalExecutor::spawn_default();
+    /// let ex = LocalExecutor::make_default();
     /// ex.run(async move {
     ///     ad.push_front(1);
     ///     ad.push_front(2);

--- a/scipio/src/collections/mod.rs
+++ b/scipio/src/collections/mod.rs
@@ -14,7 +14,7 @@
 //! use scipio::LocalExecutor;
 //!
 //! let ad : Deque<usize> = Deque::with_capacity(10);
-//! let ex = LocalExecutor::new(None).unwrap();
+//! let ex = LocalExecutor::spawn_default();
 //!
 //! ex.run(async move {
 //!     ad.push_front(1);

--- a/scipio/src/collections/mod.rs
+++ b/scipio/src/collections/mod.rs
@@ -14,7 +14,7 @@
 //! use scipio::LocalExecutor;
 //!
 //! let ad : Deque<usize> = Deque::with_capacity(10);
-//! let ex = LocalExecutor::spawn_default();
+//! let ex = LocalExecutor::make_default();
 //!
 //! ex.run(async move {
 //!     ad.push_front(1);

--- a/scipio/src/executor.rs
+++ b/scipio/src/executor.rs
@@ -344,8 +344,8 @@ impl LocalExecutorBuilder {
 
     /// Names the thread-to-be. Currently the name is used for identification
     /// only in panic messages.
-    pub fn name(mut self, name: String) -> LocalExecutorBuilder {
-        self.name = name;
+    pub fn name(mut self, name: &str) -> LocalExecutorBuilder {
+        self.name = String::from(name);
         self
     }
 

--- a/scipio/src/executor.rs
+++ b/scipio/src/executor.rs
@@ -296,19 +296,19 @@ impl ExecutorQueues {
 }
 
 /// LocalExecutor factory, which can be used in order to configure the properties of a new
-/// [`LocalExecutor`].
+/// `LocalExecutor`.
 ///
 /// Methods can be chained on it in order to configure it.
 ///
-/// The [`spawn`] method will take ownership of the builder and create an [`io::Result`] to the
-/// [`LocalExecutor`] handle with the given configuration.
+/// The `spawn` method will take ownership of the builder and create an
+/// `io::Result` to the `LocalExecutor` handle with the given configuration.
 ///
-/// The [`LocalExecutor::spawn_default`] free function uses a Builder with default configuration and
+/// The `LocalExecutor::spawn_default` free function uses a Builder with default configuration and
 /// unwraps its return value.
 ///
-/// You may want to use [`spawn`] instead of [`LocalExecutor::spawn_default`], when you want to
-/// recover from a failure to launch a thread, indeed the free function will panic where the Builder
-/// method will return a [`io::Result`].
+/// You may want to use `LocalExecutorBuilder::spawn` instead of `LocalExecutor::spawn_default`,
+/// when you want to recover from a failure to launch a thread, indeed the free function will panic
+/// where the Builder method will return a `io::Result`.
 ///
 /// # Examples
 ///

--- a/scipio/src/lib.rs
+++ b/scipio/src/lib.rs
@@ -24,7 +24,7 @@
 //! use std::net::{TcpStream, ToSocketAddrs};
 //! use std::time::Duration;
 //!
-//! let local_ex = LocalExecutor::spawn_default();
+//! let local_ex = LocalExecutor::make_default();
 //! local_ex.run(async {
 //!     let addr = "::80".to_socket_addrs()?.next().unwrap();
 //!
@@ -58,7 +58,7 @@ macro_rules! test_executor {
     use crate::executor::{LocalExecutor, Task};
     use futures::future::join_all;
 
-    let local_ex = LocalExecutor::spawn_default();
+    let local_ex = LocalExecutor::make_default();
     local_ex.run(async move {
         let mut joins = Vec::new();
         $(

--- a/scipio/src/lib.rs
+++ b/scipio/src/lib.rs
@@ -24,7 +24,7 @@
 //! use std::net::{TcpStream, ToSocketAddrs};
 //! use std::time::Duration;
 //!
-//! let local_ex = LocalExecutor::new(None).unwrap();
+//! let local_ex = LocalExecutor::spawn_default();
 //! local_ex.run(async {
 //!     let addr = "::80".to_socket_addrs()?.next().unwrap();
 //!
@@ -58,7 +58,7 @@ macro_rules! test_executor {
     use crate::executor::{LocalExecutor, Task};
     use futures::future::join_all;
 
-    let local_ex = LocalExecutor::new(None).unwrap();
+    let local_ex = LocalExecutor::spawn_default();
     local_ex.run(async move {
         let mut joins = Vec::new();
         $(
@@ -139,7 +139,9 @@ pub mod timer;
 
 pub use crate::dma_file::{Directory, DmaFile};
 pub use crate::error::Error;
-pub use crate::executor::{LocalExecutor, QueueNotFoundError, Task, TaskQueueHandle};
+pub use crate::executor::{
+    LocalExecutor, LocalExecutorBuilder, QueueNotFoundError, Task, TaskQueueHandle,
+};
 pub use crate::networking::*;
 pub use crate::pollable::Async;
 pub use crate::semaphore::Semaphore;

--- a/scipio/src/multitask.rs
+++ b/scipio/src/multitask.rs
@@ -59,7 +59,7 @@ impl<T> Task<T> {
     /// use scipio::LocalExecutor;
     /// use scipio::timer::Timer;
     ///
-    /// let ex = LocalExecutor::new(None).expect("failed to create local executor");
+    /// let ex = LocalExecutor::spawn_default();
     ///
     /// // Spawn a deamon future.
     /// ex.spawn(async {
@@ -91,7 +91,7 @@ impl<T> Task<T> {
     /// use scipio::timer::Timer;
     /// use futures_lite::future::block_on;
     ///
-    /// let ex = LocalExecutor::new(None).expect("failed to create local executor");
+    /// let ex = LocalExecutor::spawn_default();
     ///
     /// let task = ex.spawn(async {
     ///     Timer::new(std::time::Duration::from_millis(100)).await;

--- a/scipio/src/multitask.rs
+++ b/scipio/src/multitask.rs
@@ -59,7 +59,7 @@ impl<T> Task<T> {
     /// use scipio::LocalExecutor;
     /// use scipio::timer::Timer;
     ///
-    /// let ex = LocalExecutor::spawn_default();
+    /// let ex = LocalExecutor::make_default();
     ///
     /// // Spawn a deamon future.
     /// ex.spawn(async {
@@ -91,7 +91,7 @@ impl<T> Task<T> {
     /// use scipio::timer::Timer;
     /// use futures_lite::future::block_on;
     ///
-    /// let ex = LocalExecutor::spawn_default();
+    /// let ex = LocalExecutor::make_default();
     ///
     /// let task = ex.spawn(async {
     ///     Timer::new(std::time::Duration::from_millis(100)).await;

--- a/scipio/src/semaphore.rs
+++ b/scipio/src/semaphore.rs
@@ -194,7 +194,7 @@ impl Semaphore {
     ///
     /// let sem = Semaphore::new(1);
     ///
-    /// let ex = LocalExecutor::spawn_default();
+    /// let ex = LocalExecutor::make_default();
     /// ex.run(async move {
     ///     {
     ///         let permit = sem.acquire_permit(1).await.unwrap();
@@ -221,7 +221,7 @@ impl Semaphore {
     ///
     /// let sem = Semaphore::new(1);
     ///
-    /// let ex = LocalExecutor::spawn_default();
+    /// let ex = LocalExecutor::make_default();
     /// ex.run(async move {
     ///     sem.acquire(1).await.unwrap();
     ///     sem.signal(1); // Has to be signaled explicity. Be careful
@@ -252,7 +252,7 @@ impl Semaphore {
     ///
     /// let sem = Semaphore::new(0);
     ///
-    /// let ex = LocalExecutor::spawn_default();
+    /// let ex = LocalExecutor::make_default();
     /// ex.run(async move {
     ///     // Note that we can signal to expand to more units than the original capacity had.
     ///     sem.signal(1);
@@ -281,7 +281,7 @@ impl Semaphore {
     ///
     /// let sem = Semaphore::new(0);
     ///
-    /// let ex = LocalExecutor::spawn_default();
+    /// let ex = LocalExecutor::make_default();
     /// ex.run(async move {
     ///     // Note that we can signal to expand to more units than the original capacity had.
     ///     sem.close();

--- a/scipio/src/semaphore.rs
+++ b/scipio/src/semaphore.rs
@@ -194,7 +194,7 @@ impl Semaphore {
     ///
     /// let sem = Semaphore::new(1);
     ///
-    /// let ex = LocalExecutor::new(None).unwrap();
+    /// let ex = LocalExecutor::spawn_default();
     /// ex.run(async move {
     ///     {
     ///         let permit = sem.acquire_permit(1).await.unwrap();
@@ -221,7 +221,7 @@ impl Semaphore {
     ///
     /// let sem = Semaphore::new(1);
     ///
-    /// let ex = LocalExecutor::new(None).unwrap();
+    /// let ex = LocalExecutor::spawn_default();
     /// ex.run(async move {
     ///     sem.acquire(1).await.unwrap();
     ///     sem.signal(1); // Has to be signaled explicity. Be careful
@@ -252,7 +252,7 @@ impl Semaphore {
     ///
     /// let sem = Semaphore::new(0);
     ///
-    /// let ex = LocalExecutor::new(None).unwrap();
+    /// let ex = LocalExecutor::spawn_default();
     /// ex.run(async move {
     ///     // Note that we can signal to expand to more units than the original capacity had.
     ///     sem.signal(1);
@@ -281,7 +281,7 @@ impl Semaphore {
     ///
     /// let sem = Semaphore::new(0);
     ///
-    /// let ex = LocalExecutor::new(None).unwrap();
+    /// let ex = LocalExecutor::spawn_default();
     /// ex.run(async move {
     ///     // Note that we can signal to expand to more units than the original capacity had.
     ///     sem.close();

--- a/scipio/src/sys/mod.rs
+++ b/scipio/src/sys/mod.rs
@@ -103,6 +103,12 @@ pub(crate) enum PollableStatus {
     NonPollable,
 }
 
+#[derive(Debug, Copy, Clone)]
+pub(crate) enum LinkStatus {
+    Freestanding,
+    Linked,
+}
+
 #[derive(Debug)]
 pub(crate) enum SourceType {
     DmaWrite(PollableStatus),
@@ -112,7 +118,7 @@ pub(crate) enum SourceType {
     FdataSync,
     Fallocate,
     Close,
-    LinkRings(bool),
+    LinkRings(LinkStatus),
     Statx(CString, Box<RefCell<libc::statx>>),
     Timeout(bool),
     Invalid,

--- a/scipio/src/timer/timer.rs
+++ b/scipio/src/timer/timer.rs
@@ -198,7 +198,7 @@ impl<T: 'static> TimerActionOnce<T> {
     /// use scipio::timer::TimerActionOnce;
     /// use std::time::Duration;
     ///
-    /// let handle = LocalExecutorBuilder::new().spawn("test", || async move {
+    /// let handle = LocalExecutorBuilder::new().spawn(|| async move {
     ///     let action = TimerActionOnce::do_in(Duration::from_millis(100), async move {
     ///         println!("Executed once");
     ///     });
@@ -228,7 +228,7 @@ impl<T: 'static> TimerActionOnce<T> {
     /// use scipio::timer::TimerActionOnce;
     /// use std::time::Duration;
     ///
-    /// let handle = LocalExecutorBuilder::new().spawn("test", || async move {
+    /// let handle = LocalExecutorBuilder::new().spawn(|| async move {
     ///     let tq = Local::create_task_queue(1, Latency::NotImportant, "test");
     ///     let action = TimerActionOnce::do_in_into(Duration::from_millis(100), async move {
     ///         println!("Executed once");
@@ -277,7 +277,7 @@ impl<T: 'static> TimerActionOnce<T> {
     /// use scipio::timer::TimerActionOnce;
     /// use std::time::{Instant, Duration};
     ///
-    /// let handle = LocalExecutorBuilder::new().spawn("test", || async move {
+    /// let handle = LocalExecutorBuilder::new().spawn(|| async move {
     ///     let when = Instant::now().checked_add(Duration::from_millis(100)).unwrap();
     ///     let action = TimerActionOnce::do_at(when, async move {
     ///         println!("Executed once");
@@ -308,7 +308,7 @@ impl<T: 'static> TimerActionOnce<T> {
     /// use scipio::timer::TimerActionOnce;
     /// use std::time::{Instant, Duration};
     ///
-    /// let handle = LocalExecutorBuilder::new().spawn("test", || async move {
+    /// let handle = LocalExecutorBuilder::new().spawn(|| async move {
     ///     let tq = Local::create_task_queue(1, Latency::NotImportant, "test");
     ///     let when = Instant::now().checked_add(Duration::from_millis(100)).unwrap();
     ///     let action = TimerActionOnce::do_at_into(when, async move {
@@ -349,7 +349,7 @@ impl<T: 'static> TimerActionOnce<T> {
     /// use scipio::timer::TimerActionOnce;
     /// use std::time::Duration;
     ///
-    /// let handle = LocalExecutorBuilder::new().spawn("test", || async move {
+    /// let handle = LocalExecutorBuilder::new().spawn(|| async move {
     ///     let action = TimerActionOnce::do_in(Duration::from_millis(100), async move {
     ///         println!("Will not execute this");
     ///     });
@@ -378,7 +378,7 @@ impl<T: 'static> TimerActionOnce<T> {
     /// use scipio::timer::TimerActionOnce;
     /// use std::time::Duration;
     ///
-    /// let handle = LocalExecutorBuilder::new().spawn("test", || async move {
+    /// let handle = LocalExecutorBuilder::new().spawn(|| async move {
     ///     let action = TimerActionOnce::do_in(Duration::from_millis(100), async move {
     ///         println!("Will not execute this");
     ///     });
@@ -407,7 +407,7 @@ impl<T: 'static> TimerActionOnce<T> {
     /// use scipio::timer::TimerActionOnce;
     /// use std::time::Duration;
     ///
-    /// let handle = LocalExecutorBuilder::new().spawn("test", || async move {
+    /// let handle = LocalExecutorBuilder::new().spawn(|| async move {
     ///     let action = TimerActionOnce::do_in(Duration::from_millis(100), async move {
     ///         println!("Execute this in 100ms");
     ///     });
@@ -430,7 +430,7 @@ impl<T: 'static> TimerActionOnce<T> {
     /// use scipio::timer::TimerActionOnce;
     /// use std::time::Duration;
     ///
-    /// let handle = LocalExecutorBuilder::new().spawn("test", || async move {
+    /// let handle = LocalExecutorBuilder::new().spawn(|| async move {
     ///     let action = TimerActionOnce::do_in(Duration::from_millis(100), async move {
     ///         println!("hello");
     ///     });
@@ -454,7 +454,7 @@ impl<T: 'static> TimerActionOnce<T> {
     /// use scipio::timer::TimerActionOnce;
     /// use std::time::{Duration, Instant};
     ///
-    /// let handle = LocalExecutorBuilder::new().spawn("test", || async move {
+    /// let handle = LocalExecutorBuilder::new().spawn(|| async move {
     ///     let action = TimerActionOnce::do_in(Duration::from_millis(100), async move {
     ///         println!("hello");
     ///     });
@@ -495,7 +495,7 @@ impl TimerActionRepeat {
     /// use scipio::timer::TimerActionRepeat;
     /// use std::time::Duration;
     ///
-    /// let handle = LocalExecutorBuilder::new().spawn("test", || async move {
+    /// let handle = LocalExecutorBuilder::new().spawn(|| async move {
     ///     let tq = Local::create_task_queue(1, Latency::NotImportant, "test");
     ///     let action = TimerActionRepeat::repeat_into(|| async move {
     ///         println!("Execute this!");
@@ -553,7 +553,7 @@ impl TimerActionRepeat {
     /// use scipio::timer::TimerActionRepeat;
     /// use std::time::Duration;
     ///
-    /// let handle = LocalExecutorBuilder::new().spawn("test", || async move {
+    /// let handle = LocalExecutorBuilder::new().spawn(|| async move {
     ///     let action = TimerActionRepeat::repeat(|| async move {
     ///         println!("Execute this!");
     ///         Some(Duration::from_millis(100))
@@ -584,7 +584,7 @@ impl TimerActionRepeat {
     /// use scipio::timer::TimerActionRepeat;
     /// use std::time::Duration;
     ///
-    /// let handle = LocalExecutorBuilder::new().spawn("test", || async move {
+    /// let handle = LocalExecutorBuilder::new().spawn(|| async move {
     ///     let action = TimerActionRepeat::repeat(|| async move {
     ///         Some(Duration::from_millis(100))
     ///     });
@@ -613,7 +613,7 @@ impl TimerActionRepeat {
     /// use scipio::timer::TimerActionRepeat;
     /// use std::time::Duration;
     ///
-    /// let handle = LocalExecutorBuilder::new().spawn("test", || async move {
+    /// let handle = LocalExecutorBuilder::new().spawn(|| async move {
     ///     let action = TimerActionRepeat::repeat(|| async move {
     ///         Some(Duration::from_millis(100))
     ///     });
@@ -643,7 +643,7 @@ impl TimerActionRepeat {
     /// use scipio::timer::TimerActionRepeat;
     /// use std::time::Duration;
     ///
-    /// let handle = LocalExecutorBuilder::new().spawn("test", || async move {
+    /// let handle = LocalExecutorBuilder::new().spawn(|| async move {
     ///     let action = TimerActionRepeat::repeat(|| async move {
     ///         None
     ///     });

--- a/scipio/src/timer/timer.rs
+++ b/scipio/src/timer/timer.rs
@@ -225,7 +225,7 @@ impl<T: 'static> TimerActionOnce<T> {
     ///
     /// ```
     /// use scipio::{LocalExecutor, Local, Latency};
-    /// use scipio::timer::{TimerActionOnce};
+    /// use scipio::timer::TimerActionOnce;
     /// use std::time::Duration;
     ///
     /// let handle = LocalExecutor::spawn_executor("test", None, || async move {
@@ -492,7 +492,7 @@ impl TimerActionRepeat {
     ///
     /// ```no_run
     /// use scipio::{LocalExecutor, Latency, Local};
-    /// use scipio::timer::{TimerActionOnce, TimerActionRepeat};
+    /// use scipio::timer::TimerActionRepeat;
     /// use std::time::Duration;
     ///
     /// let handle = LocalExecutor::spawn_executor("test", None, || async move {
@@ -550,7 +550,7 @@ impl TimerActionRepeat {
     ///
     /// ```no_run
     /// use scipio::LocalExecutor;
-    /// use scipio::timer::{TimerActionOnce, TimerActionRepeat};
+    /// use scipio::timer::TimerActionRepeat;
     /// use std::time::Duration;
     ///
     /// let handle = LocalExecutor::spawn_executor("test", None, || async move {
@@ -581,7 +581,7 @@ impl TimerActionRepeat {
     ///
     /// ```
     /// use scipio::LocalExecutor;
-    /// use scipio::timer::{TimerActionOnce, TimerActionRepeat};
+    /// use scipio::timer::TimerActionRepeat;
     /// use std::time::Duration;
     ///
     /// let handle = LocalExecutor::spawn_executor("test", None, || async move {
@@ -610,7 +610,7 @@ impl TimerActionRepeat {
     ///
     /// ```
     /// use scipio::LocalExecutor;
-    /// use scipio::timer::{TimerActionOnce, TimerActionRepeat};
+    /// use scipio::timer::TimerActionRepeat;
     /// use std::time::Duration;
     ///
     /// let handle = LocalExecutor::spawn_executor("test", None, || async move {
@@ -640,7 +640,7 @@ impl TimerActionRepeat {
     ///
     /// ```
     /// use scipio::LocalExecutor;
-    /// use scipio::timer::{TimerActionOnce, TimerActionRepeat};
+    /// use scipio::timer::TimerActionRepeat;
     /// use std::time::Duration;
     ///
     /// let handle = LocalExecutor::spawn_executor("test", None, || async move {

--- a/scipio/src/timer/timer.rs
+++ b/scipio/src/timer/timer.rs
@@ -194,11 +194,11 @@ impl<T: 'static> TimerActionOnce<T> {
     /// # Examples
     ///
     /// ```
-    /// use scipio::LocalExecutor;
+    /// use scipio::LocalExecutorBuilder;
     /// use scipio::timer::TimerActionOnce;
     /// use std::time::Duration;
     ///
-    /// let handle = LocalExecutor::spawn_executor("test", None, || async move {
+    /// let handle = LocalExecutorBuilder::new().spawn_thread("test", || async move {
     ///     let action = TimerActionOnce::do_in(Duration::from_millis(100), async move {
     ///         println!("Executed once");
     ///     });
@@ -224,11 +224,11 @@ impl<T: 'static> TimerActionOnce<T> {
     /// # Examples
     ///
     /// ```
-    /// use scipio::{LocalExecutor, Local, Latency};
+    /// use scipio::{LocalExecutorBuilder, Local, Latency};
     /// use scipio::timer::TimerActionOnce;
     /// use std::time::Duration;
     ///
-    /// let handle = LocalExecutor::spawn_executor("test", None, || async move {
+    /// let handle = LocalExecutorBuilder::new().spawn_thread("test", || async move {
     ///     let tq = Local::create_task_queue(1, Latency::NotImportant, "test");
     ///     let action = TimerActionOnce::do_in_into(Duration::from_millis(100), async move {
     ///         println!("Executed once");
@@ -273,11 +273,11 @@ impl<T: 'static> TimerActionOnce<T> {
     /// # Examples
     ///
     /// ```
-    /// use scipio::LocalExecutor;
+    /// use scipio::LocalExecutorBuilder;
     /// use scipio::timer::TimerActionOnce;
     /// use std::time::{Instant, Duration};
     ///
-    /// let handle = LocalExecutor::spawn_executor("test", None, || async move {
+    /// let handle = LocalExecutorBuilder::new().spawn_thread("test", || async move {
     ///     let when = Instant::now().checked_add(Duration::from_millis(100)).unwrap();
     ///     let action = TimerActionOnce::do_at(when, async move {
     ///         println!("Executed once");
@@ -304,11 +304,11 @@ impl<T: 'static> TimerActionOnce<T> {
     /// # Examples
     ///
     /// ```
-    /// use scipio::{LocalExecutor, Local, Latency};
+    /// use scipio::{LocalExecutorBuilder, Local, Latency};
     /// use scipio::timer::TimerActionOnce;
     /// use std::time::{Instant, Duration};
     ///
-    /// let handle = LocalExecutor::spawn_executor("test", None, || async move {
+    /// let handle = LocalExecutorBuilder::new().spawn_thread("test", || async move {
     ///     let tq = Local::create_task_queue(1, Latency::NotImportant, "test");
     ///     let when = Instant::now().checked_add(Duration::from_millis(100)).unwrap();
     ///     let action = TimerActionOnce::do_at_into(when, async move {
@@ -345,11 +345,11 @@ impl<T: 'static> TimerActionOnce<T> {
     /// # Examples
     ///
     /// ```
-    /// use scipio::LocalExecutor;
+    /// use scipio::LocalExecutorBuilder;
     /// use scipio::timer::TimerActionOnce;
     /// use std::time::Duration;
     ///
-    /// let handle = LocalExecutor::spawn_executor("test", None, || async move {
+    /// let handle = LocalExecutorBuilder::new().spawn_thread("test", || async move {
     ///     let action = TimerActionOnce::do_in(Duration::from_millis(100), async move {
     ///         println!("Will not execute this");
     ///     });
@@ -374,11 +374,11 @@ impl<T: 'static> TimerActionOnce<T> {
     /// # Examples
     ///
     /// ```
-    /// use scipio::LocalExecutor;
+    /// use scipio::LocalExecutorBuilder;
     /// use scipio::timer::TimerActionOnce;
     /// use std::time::Duration;
     ///
-    /// let handle = LocalExecutor::spawn_executor("test", None, || async move {
+    /// let handle = LocalExecutorBuilder::new().spawn_thread("test", || async move {
     ///     let action = TimerActionOnce::do_in(Duration::from_millis(100), async move {
     ///         println!("Will not execute this");
     ///     });
@@ -403,11 +403,11 @@ impl<T: 'static> TimerActionOnce<T> {
     /// # Examples
     ///
     /// ```
-    /// use scipio::LocalExecutor;
+    /// use scipio::LocalExecutorBuilder;
     /// use scipio::timer::TimerActionOnce;
     /// use std::time::Duration;
     ///
-    /// let handle = LocalExecutor::spawn_executor("test", None, || async move {
+    /// let handle = LocalExecutorBuilder::new().spawn_thread("test", || async move {
     ///     let action = TimerActionOnce::do_in(Duration::from_millis(100), async move {
     ///         println!("Execute this in 100ms");
     ///     });
@@ -426,11 +426,11 @@ impl<T: 'static> TimerActionOnce<T> {
     /// # Examples
     ///
     /// ```
-    /// use scipio::LocalExecutor;
+    /// use scipio::LocalExecutorBuilder;
     /// use scipio::timer::TimerActionOnce;
     /// use std::time::Duration;
     ///
-    /// let handle = LocalExecutor::spawn_executor("test", None, || async move {
+    /// let handle = LocalExecutorBuilder::new().spawn_thread("test", || async move {
     ///     let action = TimerActionOnce::do_in(Duration::from_millis(100), async move {
     ///         println!("hello");
     ///     });
@@ -450,11 +450,11 @@ impl<T: 'static> TimerActionOnce<T> {
     /// # Examples
     ///
     /// ```
-    /// use scipio::LocalExecutor;
+    /// use scipio::LocalExecutorBuilder;
     /// use scipio::timer::TimerActionOnce;
     /// use std::time::{Duration, Instant};
     ///
-    /// let handle = LocalExecutor::spawn_executor("test", None, || async move {
+    /// let handle = LocalExecutorBuilder::new().spawn_thread("test", || async move {
     ///     let action = TimerActionOnce::do_in(Duration::from_millis(100), async move {
     ///         println!("hello");
     ///     });
@@ -491,11 +491,11 @@ impl TimerActionRepeat {
     /// # Examples
     ///
     /// ```no_run
-    /// use scipio::{LocalExecutor, Latency, Local};
+    /// use scipio::{LocalExecutorBuilder, Latency, Local};
     /// use scipio::timer::TimerActionRepeat;
     /// use std::time::Duration;
     ///
-    /// let handle = LocalExecutor::spawn_executor("test", None, || async move {
+    /// let handle = LocalExecutorBuilder::new().spawn_thread("test", || async move {
     ///     let tq = Local::create_task_queue(1, Latency::NotImportant, "test");
     ///     let action = TimerActionRepeat::repeat_into(|| async move {
     ///         println!("Execute this!");
@@ -549,11 +549,11 @@ impl TimerActionRepeat {
     /// # Examples
     ///
     /// ```no_run
-    /// use scipio::LocalExecutor;
+    /// use scipio::LocalExecutorBuilder;
     /// use scipio::timer::TimerActionRepeat;
     /// use std::time::Duration;
     ///
-    /// let handle = LocalExecutor::spawn_executor("test", None, || async move {
+    /// let handle = LocalExecutorBuilder::new().spawn_thread("test", || async move {
     ///     let action = TimerActionRepeat::repeat(|| async move {
     ///         println!("Execute this!");
     ///         Some(Duration::from_millis(100))
@@ -580,11 +580,11 @@ impl TimerActionRepeat {
     /// # Examples
     ///
     /// ```
-    /// use scipio::LocalExecutor;
+    /// use scipio::LocalExecutorBuilder;
     /// use scipio::timer::TimerActionRepeat;
     /// use std::time::Duration;
     ///
-    /// let handle = LocalExecutor::spawn_executor("test", None, || async move {
+    /// let handle = LocalExecutorBuilder::new().spawn_thread("test", || async move {
     ///     let action = TimerActionRepeat::repeat(|| async move {
     ///         Some(Duration::from_millis(100))
     ///     });
@@ -609,11 +609,11 @@ impl TimerActionRepeat {
     /// # Examples
     ///
     /// ```
-    /// use scipio::LocalExecutor;
+    /// use scipio::LocalExecutorBuilder;
     /// use scipio::timer::TimerActionRepeat;
     /// use std::time::Duration;
     ///
-    /// let handle = LocalExecutor::spawn_executor("test", None, || async move {
+    /// let handle = LocalExecutorBuilder::new().spawn_thread("test", || async move {
     ///     let action = TimerActionRepeat::repeat(|| async move {
     ///         Some(Duration::from_millis(100))
     ///     });
@@ -639,11 +639,11 @@ impl TimerActionRepeat {
     /// # Examples
     ///
     /// ```
-    /// use scipio::LocalExecutor;
+    /// use scipio::LocalExecutorBuilder;
     /// use scipio::timer::TimerActionRepeat;
     /// use std::time::Duration;
     ///
-    /// let handle = LocalExecutor::spawn_executor("test", None, || async move {
+    /// let handle = LocalExecutorBuilder::new().spawn_thread("test", || async move {
     ///     let action = TimerActionRepeat::repeat(|| async move {
     ///         None
     ///     });

--- a/scipio/src/timer/timer.rs
+++ b/scipio/src/timer/timer.rs
@@ -61,7 +61,7 @@ impl Inner {
 ///     Timer::new(dur).await;
 /// }
 ///
-/// let ex = LocalExecutor::new(None).expect("failed to create local executor");
+/// let ex = LocalExecutor::spawn_default();
 ///
 /// ex.run(async {
 ///     sleep(Duration::from_millis(100)).await;

--- a/scipio/src/timer/timer.rs
+++ b/scipio/src/timer/timer.rs
@@ -61,7 +61,7 @@ impl Inner {
 ///     Timer::new(dur).await;
 /// }
 ///
-/// let ex = LocalExecutor::spawn_default();
+/// let ex = LocalExecutor::make_default();
 ///
 /// ex.run(async {
 ///     sleep(Duration::from_millis(100)).await;
@@ -198,7 +198,7 @@ impl<T: 'static> TimerActionOnce<T> {
     /// use scipio::timer::TimerActionOnce;
     /// use std::time::Duration;
     ///
-    /// let handle = LocalExecutorBuilder::new().spawn_thread("test", || async move {
+    /// let handle = LocalExecutorBuilder::new().spawn("test", || async move {
     ///     let action = TimerActionOnce::do_in(Duration::from_millis(100), async move {
     ///         println!("Executed once");
     ///     });
@@ -228,7 +228,7 @@ impl<T: 'static> TimerActionOnce<T> {
     /// use scipio::timer::TimerActionOnce;
     /// use std::time::Duration;
     ///
-    /// let handle = LocalExecutorBuilder::new().spawn_thread("test", || async move {
+    /// let handle = LocalExecutorBuilder::new().spawn("test", || async move {
     ///     let tq = Local::create_task_queue(1, Latency::NotImportant, "test");
     ///     let action = TimerActionOnce::do_in_into(Duration::from_millis(100), async move {
     ///         println!("Executed once");
@@ -277,7 +277,7 @@ impl<T: 'static> TimerActionOnce<T> {
     /// use scipio::timer::TimerActionOnce;
     /// use std::time::{Instant, Duration};
     ///
-    /// let handle = LocalExecutorBuilder::new().spawn_thread("test", || async move {
+    /// let handle = LocalExecutorBuilder::new().spawn("test", || async move {
     ///     let when = Instant::now().checked_add(Duration::from_millis(100)).unwrap();
     ///     let action = TimerActionOnce::do_at(when, async move {
     ///         println!("Executed once");
@@ -308,7 +308,7 @@ impl<T: 'static> TimerActionOnce<T> {
     /// use scipio::timer::TimerActionOnce;
     /// use std::time::{Instant, Duration};
     ///
-    /// let handle = LocalExecutorBuilder::new().spawn_thread("test", || async move {
+    /// let handle = LocalExecutorBuilder::new().spawn("test", || async move {
     ///     let tq = Local::create_task_queue(1, Latency::NotImportant, "test");
     ///     let when = Instant::now().checked_add(Duration::from_millis(100)).unwrap();
     ///     let action = TimerActionOnce::do_at_into(when, async move {
@@ -349,7 +349,7 @@ impl<T: 'static> TimerActionOnce<T> {
     /// use scipio::timer::TimerActionOnce;
     /// use std::time::Duration;
     ///
-    /// let handle = LocalExecutorBuilder::new().spawn_thread("test", || async move {
+    /// let handle = LocalExecutorBuilder::new().spawn("test", || async move {
     ///     let action = TimerActionOnce::do_in(Duration::from_millis(100), async move {
     ///         println!("Will not execute this");
     ///     });
@@ -378,7 +378,7 @@ impl<T: 'static> TimerActionOnce<T> {
     /// use scipio::timer::TimerActionOnce;
     /// use std::time::Duration;
     ///
-    /// let handle = LocalExecutorBuilder::new().spawn_thread("test", || async move {
+    /// let handle = LocalExecutorBuilder::new().spawn("test", || async move {
     ///     let action = TimerActionOnce::do_in(Duration::from_millis(100), async move {
     ///         println!("Will not execute this");
     ///     });
@@ -407,7 +407,7 @@ impl<T: 'static> TimerActionOnce<T> {
     /// use scipio::timer::TimerActionOnce;
     /// use std::time::Duration;
     ///
-    /// let handle = LocalExecutorBuilder::new().spawn_thread("test", || async move {
+    /// let handle = LocalExecutorBuilder::new().spawn("test", || async move {
     ///     let action = TimerActionOnce::do_in(Duration::from_millis(100), async move {
     ///         println!("Execute this in 100ms");
     ///     });
@@ -430,7 +430,7 @@ impl<T: 'static> TimerActionOnce<T> {
     /// use scipio::timer::TimerActionOnce;
     /// use std::time::Duration;
     ///
-    /// let handle = LocalExecutorBuilder::new().spawn_thread("test", || async move {
+    /// let handle = LocalExecutorBuilder::new().spawn("test", || async move {
     ///     let action = TimerActionOnce::do_in(Duration::from_millis(100), async move {
     ///         println!("hello");
     ///     });
@@ -454,7 +454,7 @@ impl<T: 'static> TimerActionOnce<T> {
     /// use scipio::timer::TimerActionOnce;
     /// use std::time::{Duration, Instant};
     ///
-    /// let handle = LocalExecutorBuilder::new().spawn_thread("test", || async move {
+    /// let handle = LocalExecutorBuilder::new().spawn("test", || async move {
     ///     let action = TimerActionOnce::do_in(Duration::from_millis(100), async move {
     ///         println!("hello");
     ///     });
@@ -495,7 +495,7 @@ impl TimerActionRepeat {
     /// use scipio::timer::TimerActionRepeat;
     /// use std::time::Duration;
     ///
-    /// let handle = LocalExecutorBuilder::new().spawn_thread("test", || async move {
+    /// let handle = LocalExecutorBuilder::new().spawn("test", || async move {
     ///     let tq = Local::create_task_queue(1, Latency::NotImportant, "test");
     ///     let action = TimerActionRepeat::repeat_into(|| async move {
     ///         println!("Execute this!");
@@ -553,7 +553,7 @@ impl TimerActionRepeat {
     /// use scipio::timer::TimerActionRepeat;
     /// use std::time::Duration;
     ///
-    /// let handle = LocalExecutorBuilder::new().spawn_thread("test", || async move {
+    /// let handle = LocalExecutorBuilder::new().spawn("test", || async move {
     ///     let action = TimerActionRepeat::repeat(|| async move {
     ///         println!("Execute this!");
     ///         Some(Duration::from_millis(100))
@@ -584,7 +584,7 @@ impl TimerActionRepeat {
     /// use scipio::timer::TimerActionRepeat;
     /// use std::time::Duration;
     ///
-    /// let handle = LocalExecutorBuilder::new().spawn_thread("test", || async move {
+    /// let handle = LocalExecutorBuilder::new().spawn("test", || async move {
     ///     let action = TimerActionRepeat::repeat(|| async move {
     ///         Some(Duration::from_millis(100))
     ///     });
@@ -613,7 +613,7 @@ impl TimerActionRepeat {
     /// use scipio::timer::TimerActionRepeat;
     /// use std::time::Duration;
     ///
-    /// let handle = LocalExecutorBuilder::new().spawn_thread("test", || async move {
+    /// let handle = LocalExecutorBuilder::new().spawn("test", || async move {
     ///     let action = TimerActionRepeat::repeat(|| async move {
     ///         Some(Duration::from_millis(100))
     ///     });
@@ -643,7 +643,7 @@ impl TimerActionRepeat {
     /// use scipio::timer::TimerActionRepeat;
     /// use std::time::Duration;
     ///
-    /// let handle = LocalExecutorBuilder::new().spawn_thread("test", || async move {
+    /// let handle = LocalExecutorBuilder::new().spawn("test", || async move {
     ///     let action = TimerActionRepeat::repeat(|| async move {
     ///         None
     ///     });


### PR DESCRIPTION
### What does this PR do?

> This PR contains three commits each introducing an independent type.
> Pick and choose!

This PR swaps some generic types for custom ones in the interest of self
documenting code.

The main (externally visible change) is that we currently use an
`Option<usize>` to optionally bind a `LocalExecutor` to a CPU. While
this is functionally fine, it does poorly in terms of API readability.
Newcomers reading examples or the documentation will likely wonder why
`None` is frequently passed as an argument to `LocalExecutor::new` and
variants.

After merging,

```rust
let local_ex = LocalExecutor::new(None);
let local_ex = LocalExecutor::new(Some(1));
```

becomes:

```rust
let local_ex = LocalExecutor::new(CpuBinding::AnyCpu);
let local_ex = LocalExecutor::new(CpuBinding::Cpu(1));
```

### Motivation

What inspired you to submit this pull request?

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
[] The new code I am adding is formatted using `rustfmt`
