### PR TITLE
timer: Fix examples

### DIFF
--- a/scipio/src/executor.rs
+++ b/scipio/src/executor.rs
@@ -12,7 +12,8 @@
 //! Run four single-threaded executors concurrently:
 //!
 //! ```
-//! use scipio::{LocalExecutor, Timer};
+//! use scipio::LocalExecutor;
+//! use scipio::timer::Timer;
 //!
 //! for i in 0..4 {
 //!     std::thread::spawn(move || {

--- a/scipio/src/lib.rs
+++ b/scipio/src/lib.rs
@@ -144,7 +144,6 @@ pub use crate::networking::*;
 pub use crate::pollable::Async;
 pub use crate::semaphore::Semaphore;
 pub use crate::sys::DmaBuffer;
-pub use crate::timer::{Timer, TimerActionOnce, TimerActionRepeat};
 pub use enclose::enclose;
 
 /// Local is an ergonomic way to access the local executor.

--- a/scipio/src/multitask.rs
+++ b/scipio/src/multitask.rs
@@ -56,7 +56,8 @@ impl<T> Task<T> {
     ///
     /// ```
     /// use std::time::Duration;
-    /// use scipio::{LocalExecutor,Timer};
+    /// use scipio::LocalExecutor;
+    /// use scipio::timer::Timer;
     ///
     /// let ex = LocalExecutor::new(None).expect("failed to create local executor");
     ///
@@ -86,7 +87,8 @@ impl<T> Task<T> {
     /// ```
     /// use std::thread;
     /// use std::time::Duration;
-    /// use scipio::{LocalExecutor, Timer, parking};
+    /// use scipio::{LocalExecutor, parking};
+    /// use scipio::timer::Timer;
     /// use futures_lite::future::block_on;
     ///
     /// let ex = LocalExecutor::new(None).expect("failed to create local executor");

--- a/scipio/src/timer/timer.rs
+++ b/scipio/src/timer/timer.rs
@@ -195,7 +195,7 @@ impl<T: 'static> TimerActionOnce<T> {
     ///
     /// ```
     /// use scipio::LocalExecutor;
-    /// use scipio::timer::{TimerAction,TimerActionOnce};
+    /// use scipio::timer::TimerActionOnce;
     /// use std::time::Duration;
     ///
     /// let handle = LocalExecutor::spawn_executor("test", None, || async move {
@@ -225,7 +225,7 @@ impl<T: 'static> TimerActionOnce<T> {
     ///
     /// ```
     /// use scipio::{LocalExecutor, Local, Latency};
-    /// use scipio::timer::{TimerAction,TimerActionOnce};
+    /// use scipio::timer::{TimerActionOnce};
     /// use std::time::Duration;
     ///
     /// let handle = LocalExecutor::spawn_executor("test", None, || async move {
@@ -274,7 +274,7 @@ impl<T: 'static> TimerActionOnce<T> {
     ///
     /// ```
     /// use scipio::LocalExecutor;
-    /// use scipio::timer::{TimerAction, TimerActionOnce};
+    /// use scipio::timer::TimerActionOnce;
     /// use std::time::{Instant, Duration};
     ///
     /// let handle = LocalExecutor::spawn_executor("test", None, || async move {
@@ -305,7 +305,7 @@ impl<T: 'static> TimerActionOnce<T> {
     ///
     /// ```
     /// use scipio::{LocalExecutor, Local, Latency};
-    /// use scipio::timer::{TimerAction, TimerActionOnce};
+    /// use scipio::timer::TimerActionOnce;
     /// use std::time::{Instant, Duration};
     ///
     /// let handle = LocalExecutor::spawn_executor("test", None, || async move {
@@ -492,7 +492,7 @@ impl TimerActionRepeat {
     ///
     /// ```no_run
     /// use scipio::{LocalExecutor, Latency, Local};
-    /// use scipio::timer::{TimerAction, TimerActionRepeat};
+    /// use scipio::timer::{TimerActionOnce, TimerActionRepeat};
     /// use std::time::Duration;
     ///
     /// let handle = LocalExecutor::spawn_executor("test", None, || async move {
@@ -550,7 +550,7 @@ impl TimerActionRepeat {
     ///
     /// ```no_run
     /// use scipio::LocalExecutor;
-    /// use scipio::timer::{TimerAction, TimerActionRepeat};
+    /// use scipio::timer::{TimerActionOnce, TimerActionRepeat};
     /// use std::time::Duration;
     ///
     /// let handle = LocalExecutor::spawn_executor("test", None, || async move {
@@ -581,7 +581,7 @@ impl TimerActionRepeat {
     ///
     /// ```
     /// use scipio::LocalExecutor;
-    /// use scipio::timer::{TimerAction, TimerActionRepeat};
+    /// use scipio::timer::{TimerActionOnce, TimerActionRepeat};
     /// use std::time::Duration;
     ///
     /// let handle = LocalExecutor::spawn_executor("test", None, || async move {
@@ -610,7 +610,7 @@ impl TimerActionRepeat {
     ///
     /// ```
     /// use scipio::LocalExecutor;
-    /// use scipio::timer::{TimerAction, TimerActionRepeat};
+    /// use scipio::timer::{TimerActionOnce, TimerActionRepeat};
     /// use std::time::Duration;
     ///
     /// let handle = LocalExecutor::spawn_executor("test", None, || async move {
@@ -640,7 +640,7 @@ impl TimerActionRepeat {
     ///
     /// ```
     /// use scipio::LocalExecutor;
-    /// use scipio::timer::{TimerAction, TimerActionRepeat};
+    /// use scipio::timer::{TimerActionOnce, TimerActionRepeat};
     /// use std::time::Duration;
     ///
     /// let handle = LocalExecutor::spawn_executor("test", None, || async move {


### PR DESCRIPTION
PR 50 broke some of the timer examples.
It also had a small issue in that it keep the Timer structs visible
under the root scipio crate. Some tests that should have failed
passed and they are fixed now too
