### PR TITLE
fix make_test_directories to support /tmp

### DIFF
--- a/scipio/src/dma_file.rs
+++ b/scipio/src/dma_file.rs
@@ -506,6 +506,11 @@ mod test {
                 let mut dir = PathBuf::from(path);
                 std::assert!(dir.exists());
 
+                if std::env::temp_dir() == dir {
+                    dir.push("storage_media");
+                    std::fs::create_dir_all(&dir).unwrap();
+                }
+
                 dir.push(test_name);
                 let _ = std::fs::remove_dir_all(&dir);
                 std::fs::create_dir_all(&dir).unwrap();


### PR DESCRIPTION
StorageMedia and TempFs can conflict if they target the same path.
This PR adds support for `env SCIPIO_TEST_POLLIO_ROOTDIR=/tmp cargo test`