### PR TITLE
do not use our own Error type for I/O operations

### DIFF
--- a/scipio/src/error.rs
+++ b/scipio/src/error.rs
@@ -9,27 +9,20 @@ use std::path::PathBuf;
 
 /// Augments an io::Error with more information about what was happening
 /// and to which file when the error ocurred.
-pub struct Error {
+pub(crate) struct ErrorEnhancer {
     pub(crate) inner: std::io::Error,
     pub(crate) op: &'static str,
     pub(crate) path: Option<PathBuf>,
     pub(crate) fd: Option<RawFd>,
 }
 
-impl Error {
-    /// Returns the raw OS error, if there is one, associated with the inner io::Error
-    pub fn raw_os_error(&self) -> Option<i32> {
-        self.inner.raw_os_error()
-    }
-}
-
-impl fmt::Debug for Error {
+impl fmt::Debug for ErrorEnhancer {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self)
     }
 }
 
-impl fmt::Display for Error {
+impl fmt::Display for ErrorEnhancer {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}, op: {}", self.inner, self.op)?;
         if let Some(path) = &self.path.as_ref().and_then(|x| x.to_str()) {
@@ -43,14 +36,8 @@ impl fmt::Display for Error {
     }
 }
 
-impl std::error::Error for Error {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        Some(&self.inner)
-    }
-}
-
-impl From<Error> for std::io::Error {
-    fn from(err: Error) -> std::io::Error {
-        err.inner
+impl From<ErrorEnhancer> for std::io::Error {
+    fn from(err: ErrorEnhancer) -> std::io::Error {
+        std::io::Error::new(err.inner.kind(), format!("{}", err.inner))
     }
 }

--- a/scipio/src/lib.rs
+++ b/scipio/src/lib.rs
@@ -138,7 +138,6 @@ mod semaphore;
 pub mod timer;
 
 pub use crate::dma_file::{Directory, DmaFile};
-pub use crate::error::Error;
 pub use crate::executor::{
     LocalExecutor, LocalExecutorBuilder, QueueNotFoundError, Task, TaskQueueHandle,
 };
@@ -199,7 +198,3 @@ impl IoRequirements {
         }
     }
 }
-
-/// Represents a wrapper around io::Result that packs more
-/// information about the file being accessed.
-pub type Result<T> = std::result::Result<T, Error>;


### PR DESCRIPTION
io::Result is pretty much the standard everywhere else for errors resulting
from I/O operations.

I had introduced our own type earlier out of frustration for the fact that
io::Error wouldn't encode information that I considered valuable about location
of errors like the file path.

I had since discovered that this information can be added as an inner component
to io::Error. Doing that is superior to returning our own Error type because it
is easier to deal with in situations where you want to mix both. It is also
less surprising for users who are used to io::Error.

The Error struct is kept (now called ErrorEnhancer) as a convenience so we can
add the desired information to io::Error. But it is made pub(crate) so it cannot
be used outside Scipio.

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
[] The new code I am adding is formatted using `rustfmt`
