### PR TITLE
rename file by names

### DIFF
--- a/scipio/src/dma_file.rs
+++ b/scipio/src/dma_file.rs
@@ -418,11 +418,24 @@ impl DmaFile {
     /// rename an existing file.
     ///
     /// Warning: synchronous operation, will block the reactor
+    pub async fn rename_file<P: AsRef<Path>>(old_path: P, new_path: P) -> io::Result<()> {
+        let new_path = new_path.as_ref().to_owned();
+        let old_path = old_path.as_ref().to_owned();
+
+        sys::rename_file(&old_path, &new_path)
+    }
+
+    /// rename this file.
+    ///
+    /// Warning: synchronous operation, will block the reactor
     pub async fn rename<P: AsRef<Path>>(&mut self, new_path: P) -> io::Result<()> {
         let new_path = new_path.as_ref().to_owned();
         let old_path = path_required!(self, "rename")?;
-
-        enhanced_try!(sys::rename_file(&old_path, &new_path), "Renaming", self)?;
+        enhanced_try!(
+            Self::rename_file(old_path, &new_path).await,
+            "Renaming",
+            self
+        )?;
         self.path = Some(new_path);
         Ok(())
     }


### PR DESCRIPTION
rename() is a syscall that takes two file paths. While it may be convenient to
be able to rename the current file, there are situations in which it is not:
for instance, if we have a file stream, where there is no direct access to the
underlying file.

While we could somehow implement rename for the file stream, it is more general
to just provide a rename version that matches what Linux would expect.
