### PR TITLE
return a ReadResult from read_dma and read_dma_aligned

### DIFF
--- a/scipio/src/lib.rs
+++ b/scipio/src/lib.rs
@@ -137,6 +137,7 @@ mod file_stream;
 mod multitask;
 mod networking;
 mod pollable;
+mod read_result;
 mod semaphore;
 pub mod timer;
 
@@ -145,10 +146,11 @@ pub use crate::executor::{
     LocalExecutor, LocalExecutorBuilder, QueueNotFoundError, Task, TaskQueueHandle,
 };
 pub use crate::file_stream::{
-    ReadResult, StreamReader, StreamReaderBuilder, StreamWriter, StreamWriterBuilder,
+    StreamReader, StreamReaderBuilder, StreamWriter, StreamWriterBuilder,
 };
 pub use crate::networking::*;
 pub use crate::pollable::Async;
+pub use crate::read_result::ReadResult;
 pub use crate::semaphore::Semaphore;
 pub use crate::sys::DmaBuffer;
 pub use enclose::enclose;


### PR DESCRIPTION
Right now that doesn't buy as much, but I'd like us to make as much
API visible changes as possible before publishing on crates.

Long term, the goal of this would be reuse buffers for many reads
if they happen to read from the same location.
