### PR TITLE
facility to allow testing if two files are the same

### DIFF
--- a/scipio/src/dma_file.rs
+++ b/scipio/src/dma_file.rs
@@ -257,7 +257,15 @@ I will close it and turn a leak bug into a performance bug. Please investigate",
 }
 
 impl DmaFile {
-    /// Returns true if the files represent the same file on the underlying device.
+    /// Returns true if the DmaFiles represent the same file on the underlying device.
+    ///
+    /// Files are considered to be the same if they live in the same file system and
+    /// have the same Linux inode. Note that based on this rule a symlink is *not*
+    /// considered to be the same file.
+    ///
+    /// Files will be considered to be the same if:
+    /// * A file is opened multiple times (different file descriptors, but same file!)
+    /// * they are hard links.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
file1 == file2 tests for object equality: it will return true if
the two files are the same file descriptors. However it is possible for:

- hard links to exist
- open a file more than once.

In which case they will represent the same on-storage entity but will be
represented by two different objects. This patch adds a facility that
allows us to test for that.
