### PR TITLE
need_preempt: allow users to use need_preempt() directly

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -23,3 +23,7 @@ path = "ping_pong.rs"
 [[example]]
 name = "defer"
 path = "defer.rs"
+
+[[example]]
+name = "cooperative_preempt"
+path = "cooperative_preempt.rs"

--- a/examples/cooperative_preempt.rs
+++ b/examples/cooperative_preempt.rs
@@ -1,0 +1,84 @@
+use futures::join;
+use scipio::{Latency, Local, LocalExecutorBuilder};
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::time::{Duration, Instant};
+
+fn main() {
+    // Scipio is a cooperative thread per core system so once you start processing a future
+    // it will run it to completion. This is not great for latency, and may be outright wrong
+    // if you have tasks that may spin forever before returning, like a long-lived server.
+    //
+    // Applications using Scipio are then expected to be well-behaved and explicitly yield
+    // control if they are going to do something that may take too long (that is usually a
+    // loop!)
+    //
+    // There are two ways of yielding control:
+    //
+    //  * Local::yield_if_needed(), which will yield if the task has run for too long.
+    //    What "too long" means is an implementation detail, but it will be always somehow
+    //    related to the latency guarantees that the task queues want to uphold in their
+    //    `Latency::Matters` parameter (or Latency::NotImportant).
+    //
+    //  * Local::later(), which will yield immediately (execute the rest of the function
+    //    later).
+    //
+    // Because yield_if_needed() returns a future that has to be .awaited, it cannot be used
+    // in situations where .await is illegal. For instance, if we are holding a borrow.
+    // For those, one can call need_preempt() which will tell you if yielding is needed, and
+    // then explicitly yield with later().
+    let handle = LocalExecutorBuilder::new()
+        .spawn(|| async move {
+            let tq1 =
+                Local::create_task_queue(1, Latency::Matters(Duration::from_millis(10)), "tq1");
+            let tq2 =
+                Local::create_task_queue(1, Latency::Matters(Duration::from_millis(10)), "tq1");
+            let shared_value = Rc::new(RefCell::new(0u64));
+
+            let value = shared_value.clone();
+            let j2 = Local::local_into(
+                async move {
+                    let start = Instant::now();
+                    let mut lap = start;
+                    while start.elapsed().as_millis() < 50 {
+                        Local::yield_if_needed().await;
+                        if lap.elapsed().as_millis() > 1 {
+                            lap = Instant::now();
+                            println!("tq1: 1ms");
+                        }
+                    }
+                    println!("tq1: Final value of v: {}", *(value.borrow()));
+                },
+                tq1,
+            )
+            .unwrap();
+
+            let value = shared_value.clone();
+            let j1 = Local::local_into(
+                async move {
+                    let start = Instant::now();
+                    let mut lap = start;
+                    while start.elapsed().as_millis() < 50 {
+                        let mut v = value.borrow_mut();
+                        if Local::need_preempt() {
+                            drop(v);
+                            Local::later().await;
+                        } else {
+                            *v += 1;
+                        }
+                        if lap.elapsed().as_millis() > 1 {
+                            lap = Instant::now();
+                            println!("tq2: 1ms");
+                        }
+                    }
+                    println!("tq2: Final value of v: {}", *(value.borrow()));
+                },
+                tq2,
+            )
+            .unwrap();
+
+            join!(j1, j2);
+        })
+        .unwrap();
+    handle.join().unwrap();
+}

--- a/scipio/src/executor.rs
+++ b/scipio/src/executor.rs
@@ -844,6 +844,33 @@ impl<T> Task<T> {
         y.await;
     }
 
+    /// checks if this task has ran for too long and need to be preempted. This is useful for
+    /// situations where we can't call .await, for instance, if a [`RefMut`] is held. If this
+    /// tests true, then the user is responsible for making any preparations necessary for
+    /// calling .await and doing it themselves.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use scipio::{LocalExecutorBuilder, Local};
+    ///
+    /// let ex = LocalExecutorBuilder::new().spawn(|| async {
+    ///     loop {
+    ///         if Local::need_preempt() {
+    ///             break;
+    ///         }
+    ///     }
+    /// }).unwrap();
+    ///
+    /// ex.join().unwrap();
+    /// ```
+    ///
+    /// [`RefMut`]: https://doc.rust-lang.org/std/cell/struct.RefMut.html
+    #[inline]
+    pub fn need_preempt() -> bool {
+        Reactor::need_preempt()
+    }
+
     /// Conditionally yields the current task, moving it back to the end of its queue, if the task
     /// has run for too long
     #[inline]


### PR DESCRIPTION
We have been enclosing need_preept() into a helper yield_if_needed()
that returns a future, allowing the user the convenience of .awaiting
directly on it.

However there are situations where we can't really .await, for example
if we have a borrow. For those, export need_preempt() directly. It
comes with an example of how to use each in the examples directory.

