### PR TITLE
move the DmaBuffer to the io submodule too

### DIFF
--- a/scipio/src/io/mod.rs
+++ b/scipio/src/io/mod.rs
@@ -29,3 +29,4 @@ mod read_result;
 pub use self::dma_file::{Directory, DmaFile};
 pub use self::file_stream::{StreamReader, StreamReaderBuilder, StreamWriter, StreamWriterBuilder};
 pub use self::read_result::ReadResult;
+pub use crate::sys::DmaBuffer;

--- a/scipio/src/lib.rs
+++ b/scipio/src/lib.rs
@@ -145,7 +145,6 @@ pub use crate::executor::{
 pub use crate::networking::*;
 pub use crate::pollable::Async;
 pub use crate::semaphore::Semaphore;
-pub use crate::sys::DmaBuffer;
 pub use enclose::enclose;
 pub use scopeguard::defer;
 


### PR DESCRIPTION
it was mostly an oversight that it was not moved by the last patch
