### PR TITLE
Cleanup: replace a macro with an equivalent function

### DIFF
--- a/scipio/src/io/file_stream.rs
+++ b/scipio/src/io/file_stream.rs
@@ -1376,21 +1376,20 @@ mod test {
         reader.close().await.unwrap();
     });
 
-    macro_rules! expect_specific_error {
-        ( $op:expr, $err:expr ) => {
-            match $op {
-                Ok(_) => panic!("should have failed"),
-                Err(x) => {
-                    let kind = x.kind();
-                    match kind {
-                        io::ErrorKind::Other => {
-                            assert_eq!($err, format!("{:?}", x.into_inner().unwrap()));
-                        }
-                        _ => panic!("Wrong error"),
+    #[track_caller]
+    fn expect_specific_error<T>(op: Result<T, io::Error>, expected_err: &'static str) {
+        match op {
+            Ok(_) => panic!("should have failed"),
+            Err(err) => {
+                let kind = err.kind();
+                match kind {
+                    io::ErrorKind::Other => {
+                        assert_eq!(expected_err, format!("{:?}", err.into_inner().unwrap()));
                     }
+                    _ => panic!("Wrong error"),
                 }
             }
-        };
+        }
     }
 
     file_stream_read_test!(read_close_twice, path, _k, file, _file_size: 131072, {
@@ -1399,7 +1398,7 @@ mod test {
             .build();
 
         reader.close().await.unwrap();
-        expect_specific_error!(reader.close().await, "\"Bad file descriptor (os error 9)\"");
+        expect_specific_error(reader.close().await, "\"Bad file descriptor (os error 9)\"");
     });
 
     file_stream_read_test!(read_wronly_file, path, _k, _file, _file_size: 131072, {
@@ -1410,7 +1409,7 @@ mod test {
             .build();
 
         let mut buf = [0u8; 2000];
-        expect_specific_error!(reader.read_exact(&mut buf).await, "\"Bad file descriptor (os error 9)\"");
+        expect_specific_error(reader.read_exact(&mut buf).await, "\"Bad file descriptor (os error 9)\"");
         reader.close().await.unwrap();
     });
 
@@ -1471,7 +1470,7 @@ mod test {
             .build();
 
         writer.close().await.unwrap();
-        expect_specific_error!(writer.close().await, "\"Bad file descriptor (os error 9)\"");
+        expect_specific_error(writer.close().await, "\"Bad file descriptor (os error 9)\"");
     });
 
     file_stream_write_test!(write_no_write_behind, path, _k, filename, file, {
@@ -1537,7 +1536,7 @@ mod test {
             writer.write_all(&[i as u8]).await.unwrap();
         }
 
-        expect_specific_error!(writer.close().await, "\"Bad file descriptor (os error 9)\"");
+        expect_specific_error(writer.close().await, "\"Bad file descriptor (os error 9)\"");
     });
 
     file_stream_write_test!(flushed_position_small_buffer, path, _k, filename, file, {


### PR DESCRIPTION
### What does this PR do?

Strength reduction -- one doesn't need a macro where a function call would do.

### Motivation

I've noticed that scipio has a higher-than-average number of macros. I would like to push the code style to a less macro-heavy side :) I am not a fan of macros for two reasons:

* they make reading code more difficult. When I read plain code, I can get a general picture of what is happening, even if I am not familiar with specific helper functions called. When I read code inside the macro call, I have no idea about what is happening until I consult the declaration/docs of the macro
* macros break ide support in [interesing](https://github.com/matklad/proc-caesar) [ways](https://rust-analyzer.github.io/blog/2020/03/30/macros-vs-rename.html). While we should probably just poke those lazy IDE writers to fix their stuff, it wouldn't hurt to use less macros while IDEs are not yet there :D 

Now, I am not sure if macros in scipio are essential, but I have a hunch that many of them are gratuitous and can be replaced with functions and traits. Here's one specific I've found. 

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
[x] The new code I am adding is formatted using `rustfmt`
