### PR TITLE
Remove unused futures import

### DIFF
--- a/scipio/src/io/file_stream.rs
+++ b/scipio/src/io/file_stream.rs
@@ -12,14 +12,14 @@ use crate::Local;
 use core::task::Waker;
 use futures::future::join_all;
 use futures::io::{AsyncRead, AsyncWrite};
-use futures::task::{Context, Poll};
-use futures_lite::Future;
 use std::cell::RefCell;
 use std::cmp::Reverse;
 use std::collections::{HashMap, VecDeque};
+use std::future::Future;
 use std::io;
 use std::pin::Pin;
 use std::rc::Rc;
+use std::task::{Context, Poll};
 use std::vec::Vec;
 
 macro_rules! current_error {

--- a/scipio/src/semaphore.rs
+++ b/scipio/src/semaphore.rs
@@ -3,13 +3,13 @@
 //
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
 //
-use futures::prelude::*;
-use futures::task::{Context, Poll, Waker};
 use std::cell::RefCell;
 use std::collections::{HashMap, VecDeque};
+use std::future::Future;
 use std::io::{Error, ErrorKind, Result};
 use std::pin::Pin;
 use std::rc::Rc;
+use std::task::{Context, Poll, Waker};
 
 #[derive(Debug)]
 struct WaiterId(u64);


### PR DESCRIPTION
### What does this PR do?

Removes 3rd party API in favor of stdlib one

### Additional Notes

I've noticed that scipio uses both `futures` and `futures-lite`. This seems unfortunate, I suggest sticking to the `-lite` version. 

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
[x] The new code I am adding is formatted using `rustfmt`
