### PR TITLE
Optimize Semaphore::try_wake_one

### DIFF
--- a/scipio/src/semaphore.rs
+++ b/scipio/src/semaphore.rs
@@ -260,13 +260,10 @@ impl Semaphore {
     /// });
     /// ```
     pub fn signal(&self, units: u64) {
-        self.state.borrow_mut().signal(units);
-        loop {
-            if let Some(waiter) = self.state.borrow_mut().try_wake_one() {
-                waiter.wake();
-            } else {
-                return;
-            }
+        let mut state = self.state.borrow_mut();
+        state.signal(units);
+        while let Some(waiter) = state.try_wake_one() {
+            waiter.wake();
         }
     }
 


### PR DESCRIPTION
### What does this PR do?

Avoid double lookup in a hash-map by utilizing the [entry API](https://doc.rust-lang.org/stable/std/collections/struct.HashMap.html#method.entry).

### Motivation

Duplicate hashmap lookups are just a smell

### Related issues

Builds on #86 

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
[x] The new code I am adding is formatted using `rustfmt`
