### PR TITLE
Fix unsound aliasing in PosixDmaBuf

### DIFF
--- a/scipio/src/io/dma_file.rs
+++ b/scipio/src/io/dma_file.rs
@@ -726,7 +726,7 @@ pub(crate) mod test {
             .await
             .expect("failed to create file");
 
-        let buf = DmaBuffer::new(4096).expect("failed to allocate dma buffer");
+        let mut buf = DmaBuffer::new(4096).expect("failed to allocate dma buffer");
         buf.memset(42);
         new_file.write_dma(&buf, 0).await.expect("failed to write");
         new_file.close().await.expect("failed to close file");

--- a/scipio/src/io/file_stream.rs
+++ b/scipio/src/io/file_stream.rs
@@ -693,7 +693,7 @@ struct StreamWriterState {
     file_status: FileStatus,
     error: Option<io::Error>,
     pending: Vec<task::JoinHandle<(), ()>>,
-    buffer_queue: VecDeque<Rc<DmaBuffer>>,
+    buffer_queue: VecDeque<DmaBuffer>,
     file_pos: u64,
     // this is so we track the last flushed pos. Buffers may return
     // out of order, so we can't report them as flushed_pos yet. Store for
@@ -787,12 +787,7 @@ impl StreamWriterState {
         std::mem::replace(&mut self.pending, Vec::new())
     }
 
-    fn flush_one_buffer(
-        &mut self,
-        buffer: Rc<DmaBuffer>,
-        state: Rc<RefCell<Self>>,
-        file: Rc<DmaFile>,
-    ) {
+    fn flush_one_buffer(&mut self, buffer: DmaBuffer, state: Rc<RefCell<Self>>, file: Rc<DmaFile>) {
         let file_pos = self.file_pos;
         self.file_pos += self.buffer_size as u64;
         self.buffer_pos = 0;
@@ -849,7 +844,7 @@ impl StreamWriter {
     fn new(builder: StreamWriterBuilder) -> StreamWriter {
         let mut buffer_queue = VecDeque::with_capacity(builder.write_behind);
         for _ in 0..builder.write_behind {
-            buffer_queue.push_back(Rc::new(DmaFile::alloc_dma_buffer(builder.buffer_size)));
+            buffer_queue.push_back(DmaFile::alloc_dma_buffer(builder.buffer_size));
         }
 
         let state = StreamWriterState {
@@ -1003,7 +998,7 @@ impl AsyncWrite for StreamWriter {
                 None => {
                     break;
                 }
-                Some(buffer) => {
+                Some(mut buffer) => {
                     let size = buf.len();
                     let space = state.buffer_size - state.buffer_pos;
                     let writesz = std::cmp::min(space, size - written);

--- a/scipio/src/sys/posix_buffers.rs
+++ b/scipio/src/sys/posix_buffers.rs
@@ -20,20 +20,6 @@ pub struct PosixDmaBuffer {
     size: usize,
 }
 
-// Adapted from stdlib's source code, simplified because we only ever need u8.
-fn is_nonoverlapping(src: *const u8, dst: *const u8, size: usize) -> bool {
-    let src_usize = src as usize;
-    let dst_usize = dst as usize;
-    let diff = if src_usize > dst_usize {
-        src_usize - dst_usize
-    } else {
-        dst_usize - src_usize
-    };
-    // If the absolute distance between the ptrs is at least as big as the size of the buffer,
-    // they do not overlap.
-    diff >= size
-}
-
 impl PosixDmaBuffer {
     pub(crate) fn new(size: usize) -> Option<PosixDmaBuffer> {
         let data = aligned_alloc(size, 4 << 10) as *mut u8;
@@ -68,7 +54,7 @@ impl PosixDmaBuffer {
         self.size
     }
 
-    pub fn as_mut_ptr(&self) -> *mut u8 {
+    pub fn as_mut_ptr(&mut self) -> *mut u8 {
         unsafe { self.data.as_ptr().add(self.trim) }
     }
 
@@ -82,25 +68,23 @@ impl PosixDmaBuffer {
         }
         let len = std::cmp::min(dst.len(), self.size - offset);
 
-        let dst_ptr = dst.as_mut_ptr() as *mut u8;
-        assert_eq!(is_nonoverlapping(self.as_ptr(), dst_ptr, len), true);
+        let dst_ptr = dst.as_mut_ptr();
         unsafe { std::ptr::copy_nonoverlapping(self.as_ptr().add(offset), dst_ptr, len) }
         len
     }
 
-    pub fn copy_from_slice(&self, offset: usize, src: &[u8]) -> usize {
+    pub fn copy_from_slice(&mut self, offset: usize, src: &[u8]) -> usize {
         if offset > self.size {
             return 0;
         }
         let len = std::cmp::min(src.len(), self.size - offset);
 
-        let src_ptr = src.as_ptr() as *const u8;
-        assert_eq!(is_nonoverlapping(src_ptr, self.as_ptr(), len), true);
+        let src_ptr = src.as_ptr();
         unsafe { std::ptr::copy_nonoverlapping(src_ptr, self.as_mut_ptr().add(offset), len) }
         len
     }
 
-    pub fn memset(&self, value: u8) {
+    pub fn memset(&mut self, value: u8) {
         unsafe { std::ptr::write_bytes(self.as_mut_ptr(), value, self.size) }
     }
 }


### PR DESCRIPTION
### What does this PR do?

Require exclusive access when writing to a PosixDmaBuf

Fixes
https://github.com/DataDog/scipio/issues/79#issuecomment-702934315

Note that this also removes `is_nonoverlapping` assertion -- it is now
lifted into the type system, `&[u8]` and `&mut [u8]` can't overlap.

I also have a hunch that we don't actually *need* these functions at
all, as they can be implemented by calling `.as_bytes[_mut]` and
https://doc.rust-lang.org/stable/std/primitive.slice.html#method.copy_from_slice,
but that can be left to the follow-up work.

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
[x] The new code I am adding is formatted using `rustfmt`
