### PR TITLE
Closing files and streams consume them

### DIFF
--- a/scipio/src/io/dma_file.rs
+++ b/scipio/src/io/dma_file.rs
@@ -8,9 +8,9 @@ use crate::parking::Reactor;
 use crate::sys;
 use crate::sys::sysfs;
 use crate::sys::{DmaBuffer, PollableStatus, SourceType};
-use std::io;
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use std::path::{Path, PathBuf};
+use std::{io, rc::Rc};
 
 pub(crate) fn align_up(v: u64, align: u64) -> u64 {
     (v + align - 1) & !(align - 1)
@@ -458,6 +458,15 @@ impl DmaFile {
         enhanced_try!(source.collect_rw().await, "Closing", self)?;
         self.file = unsafe { std::fs::File::from_raw_fd(-1) };
         Ok(())
+    }
+    pub(crate) async fn close_rc(this: &mut Rc<DmaFile>) -> io::Result<()> {
+        match Rc::get_mut(this) {
+            None => Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!("{} references to file still held", Rc::strong_count(&this)),
+            )),
+            Some(file) => file.close().await,
+        }
     }
 }
 


### PR DESCRIPTION
### What does this PR do?

Change close from `&mut self` to `self`

### Motivation

Splitting signature-change part of #92.

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
[x] The new code I am adding is formatted using `rustfmt`
