### PR TITLE
improve modularity of rename and remove

### DIFF
--- a/scipio/src/io/mod.rs
+++ b/scipio/src/io/mod.rs
@@ -22,6 +22,59 @@
 //! every call is expected to reach the media. Especially for random I/O, this can be very
 //! detrimental without a user-provided cache. This means that those entities are better
 //! used in conjunction with your own cache.
+macro_rules! enhanced_try {
+    ($expr:expr, $op:expr, $path:expr, $fd:expr) => {{
+        match $expr {
+            Ok(val) => Ok(val),
+            Err(inner) => {
+                let enhanced: std::io::Error = crate::error::ErrorEnhancer {
+                    inner,
+                    op: $op,
+                    path: $path.and_then(|x| Some(x.to_path_buf())),
+                    fd: $fd,
+                }
+                .into();
+                Err(enhanced)
+            }
+        }
+    }};
+    ($expr:expr, $op:expr, $obj:expr) => {{
+        enhanced_try!(
+            $expr,
+            $op,
+            $obj.path.as_ref().and_then(|x| Some(x.as_path())),
+            Some($obj.as_raw_fd())
+        )
+    }};
+}
+
+macro_rules! path_required {
+    ($obj:expr, $op:expr) => {{
+        $obj.path.as_ref().ok_or(crate::error::ErrorEnhancer {
+            inner: std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "operation requires a valid path",
+            ),
+            op: $op,
+            path: None,
+            fd: Some($obj.as_raw_fd()),
+        })
+    }};
+}
+
+macro_rules! bad_buffer {
+    ($obj:expr) => {{
+        let enhanced: std::io::Error = crate::error::ErrorEnhancer {
+            inner: std::io::Error::from_raw_os_error(5),
+            op: "processing read buffer",
+            path: $obj.path.clone(),
+            fd: Some($obj.as_raw_fd()),
+        }
+        .into();
+        enhanced
+    }};
+}
+
 mod dma_file;
 mod file_stream;
 mod read_result;

--- a/scipio/src/io/mod.rs
+++ b/scipio/src/io/mod.rs
@@ -79,6 +79,32 @@ mod dma_file;
 mod file_stream;
 mod read_result;
 
+use crate::sys;
+use std::io;
+use std::path::Path;
+
+/// rename an existing file.
+///
+/// Warning: synchronous operation, will block the reactor
+pub async fn rename_file<P: AsRef<Path>>(old_path: P, new_path: P) -> io::Result<()> {
+    let new_path = new_path.as_ref().to_owned();
+    let old_path = old_path.as_ref().to_owned();
+
+    sys::rename_file(&old_path, &new_path)
+}
+
+/// remove an existing file given its name
+///
+/// Warning: synchronous operation, will block the reactor
+pub async fn remove_file<P: AsRef<Path>>(path: P) -> io::Result<()> {
+    enhanced_try!(
+        sys::remove_file(path.as_ref()),
+        "Removing",
+        Some(path.as_ref()),
+        None
+    )
+}
+
 pub use self::dma_file::{Directory, DmaFile};
 pub use self::file_stream::{StreamReader, StreamReaderBuilder, StreamWriter, StreamWriterBuilder};
 pub use self::read_result::ReadResult;


### PR DESCRIPTION
### What does this PR do?

modularizes rename and remove, detaching them from the DmaFile api.

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
[x] The new code I am adding is formatted using `rustfmt`
