### PR TITLE
make sure that the enhanced io::Error correctly implements into_inner()

### DIFF
--- a/scipio/src/error.rs
+++ b/scipio/src/error.rs
@@ -38,6 +38,6 @@ impl fmt::Display for ErrorEnhancer {
 
 impl From<ErrorEnhancer> for std::io::Error {
     fn from(err: ErrorEnhancer) -> std::io::Error {
-        err.inner
+        std::io::Error::new(err.inner.kind(), format!("{}", err.inner))
     }
 }


### PR DESCRIPTION
The Enhanced Error mechanism expects err.into_inner() to work and the extended
message to be present in the inner field of io::Error

Commit 9c2b203568bcd4855ef876b42119de8e6bdfa33d broke this, by simply returning
inner without enhancing it.
