### PR TITLE
add tests for ErrorEnhancer, and fix into_inner()

### DIFF
--- a/scipio/src/io/file_stream.rs
+++ b/scipio/src/io/file_stream.rs
@@ -1384,7 +1384,8 @@ mod test {
                 let kind = err.kind();
                 match kind {
                     io::ErrorKind::Other => {
-                        assert_eq!(expected_err, format!("{:?}", err.into_inner().unwrap()));
+                        let x = format!("{}", err.into_inner().unwrap());
+                        assert!(x.starts_with(expected_err));
                     }
                     _ => panic!("Wrong error"),
                 }
@@ -1398,7 +1399,7 @@ mod test {
             .build();
 
         reader.close().await.unwrap();
-        expect_specific_error(reader.close().await, "\"Bad file descriptor (os error 9)\"");
+        expect_specific_error(reader.close().await, "Bad file descriptor (os error 9)");
     });
 
     file_stream_read_test!(read_wronly_file, path, _k, _file, _file_size: 131072, {
@@ -1409,7 +1410,7 @@ mod test {
             .build();
 
         let mut buf = [0u8; 2000];
-        expect_specific_error(reader.read_exact(&mut buf).await, "\"Bad file descriptor (os error 9)\"");
+        expect_specific_error(reader.read_exact(&mut buf).await, "Bad file descriptor (os error 9)");
         reader.close().await.unwrap();
     });
 
@@ -1470,7 +1471,7 @@ mod test {
             .build();
 
         writer.close().await.unwrap();
-        expect_specific_error(writer.close().await, "\"Bad file descriptor (os error 9)\"");
+        expect_specific_error(writer.close().await, "Bad file descriptor (os error 9)");
     });
 
     file_stream_write_test!(write_no_write_behind, path, _k, filename, file, {
@@ -1536,7 +1537,7 @@ mod test {
             writer.write_all(&[i as u8]).await.unwrap();
         }
 
-        expect_specific_error(writer.close().await, "\"Bad file descriptor (os error 9)\"");
+        expect_specific_error(writer.close().await, "Bad file descriptor (os error 9)");
     });
 
     file_stream_write_test!(flushed_position_small_buffer, path, _k, filename, file, {


### PR DESCRIPTION
ErrorEnhancer doesn't have its own tests. Instead it is relying on
indirect unit tests in other parts of the crate that deals with errors.

And guess what? It broke.

This patch adds unit tests specifically targetted at making sure that
the ErrorEnhancer is working and doing what it is supposed to do, and
relaxes the error condition in the other files that were checking for
specific error strings.

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[x] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
[x] The new code I am adding is formatted using `rustfmt`
