### PR TITLE
cleanup remove, rename

### DIFF
--- a/scipio/src/io/dma_file.rs
+++ b/scipio/src/io/dma_file.rs
@@ -409,14 +409,13 @@ impl DmaFile {
     ///
     /// Warning: synchronous operation, will block the reactor
     pub async fn rename<P: AsRef<Path>>(&mut self, new_path: P) -> io::Result<()> {
-        let new_path = new_path.as_ref().to_owned();
         let old_path = path_required!(self, "rename")?;
         enhanced_try!(
-            crate::io::rename_file(old_path, &new_path).await,
+            crate::io::rename(old_path, &new_path).await,
             "Renaming",
             self
         )?;
-        self.path = Some(new_path);
+        self.path = Some(new_path.as_ref().to_owned());
         Ok(())
     }
 

--- a/scipio/src/io/mod.rs
+++ b/scipio/src/io/mod.rs
@@ -86,17 +86,14 @@ use std::path::Path;
 /// rename an existing file.
 ///
 /// Warning: synchronous operation, will block the reactor
-pub async fn rename_file<P: AsRef<Path>>(old_path: P, new_path: P) -> io::Result<()> {
-    let new_path = new_path.as_ref().to_owned();
-    let old_path = old_path.as_ref().to_owned();
-
-    sys::rename_file(&old_path, &new_path)
+pub async fn rename<P: AsRef<Path>, Q: AsRef<Path>>(old_path: P, new_path: Q) -> io::Result<()> {
+    sys::rename_file(&old_path.as_ref(), &new_path.as_ref())
 }
 
 /// remove an existing file given its name
 ///
 /// Warning: synchronous operation, will block the reactor
-pub async fn remove_file<P: AsRef<Path>>(path: P) -> io::Result<()> {
+pub async fn remove<P: AsRef<Path>>(path: P) -> io::Result<()> {
     enhanced_try!(
         sys::remove_file(path.as_ref()),
         "Removing",


### PR DESCRIPTION
As suggested by Aleksey:
- no need to to_owned() in rename anymore, as we don't keep a copy
  in the top-level version
- since there is no more name conflict, call them remove and rename
  and drop the _file suffix.
