### PR TITLE
remove unnecessary use of unsafe in buffers

### DIFF
--- a/scipio/src/io/file_stream.rs
+++ b/scipio/src/io/file_stream.rs
@@ -212,7 +212,7 @@ impl StreamReaderState {
                 panic!("Buffer not found. But we should only call this function after we verified that all buffers exist");
             }
             Some(buffer) => {
-                len = buffer.copy_to_slice(in_buffer_offset, &mut result[..max_len]);
+                len = buffer.read_at(in_buffer_offset, &mut result[..max_len]);
             }
         }
         len
@@ -985,7 +985,7 @@ impl AsyncWrite for StreamWriter {
                     let space = state.buffer_size - state.buffer_pos;
                     let writesz = std::cmp::min(space, size - written);
                     let end = written + writesz;
-                    buffer.copy_from_slice(state.buffer_pos, &buf[written..end]);
+                    buffer.write_at(state.buffer_pos, &buf[written..end]);
                     written += writesz;
                     state.buffer_pos += writesz;
                     if state.buffer_pos == state.buffer_size {

--- a/scipio/src/io/read_result.rs
+++ b/scipio/src/io/read_result.rs
@@ -36,9 +36,9 @@ impl ReadResult {
     /// or `dst` doesn't have more space to hold them.
     ///
     /// [`ReadResult`]: struct.ReadResult.html
-    pub fn copy_to_slice(&self, offset: usize, dst: &mut [u8]) -> usize {
+    pub fn read_at(&self, offset: usize, dst: &mut [u8]) -> usize {
         let offset = self.offset + offset;
-        self.buffer.copy_to_slice(offset, dst)
+        self.buffer.read_at(offset, dst)
     }
 
     /// Creates a slice of this ReadResult with the given offset and length.

--- a/scipio/src/sys/posix_buffers.rs
+++ b/scipio/src/sys/posix_buffers.rs
@@ -62,25 +62,23 @@ impl PosixDmaBuffer {
         unsafe { self.data.as_ptr().add(self.trim) }
     }
 
-    pub fn copy_to_slice(&self, offset: usize, dst: &mut [u8]) -> usize {
+    pub fn read_at(&self, offset: usize, dst: &mut [u8]) -> usize {
         if offset > self.size {
             return 0;
         }
         let len = std::cmp::min(dst.len(), self.size - offset);
-
-        let dst_ptr = dst.as_mut_ptr();
-        unsafe { std::ptr::copy_nonoverlapping(self.as_ptr().add(offset), dst_ptr, len) }
+        let me = &self.as_bytes()[offset..offset + len];
+        dst[0..len].copy_from_slice(me);
         len
     }
 
-    pub fn copy_from_slice(&mut self, offset: usize, src: &[u8]) -> usize {
+    pub fn write_at(&mut self, offset: usize, src: &[u8]) -> usize {
         if offset > self.size {
             return 0;
         }
         let len = std::cmp::min(src.len(), self.size - offset);
-
-        let src_ptr = src.as_ptr();
-        unsafe { std::ptr::copy_nonoverlapping(src_ptr, self.as_mut_ptr().add(offset), len) }
+        let me = &mut self.as_bytes_mut()[offset..offset + len];
+        me.copy_from_slice(&src[0..len]);
         len
     }
 


### PR DESCRIPTION
After Aleksey's good work, there are still two usages of unsafe inside
DmaBuffer that could be avoided.

Aleksey suggests we could probably just use the standard function
copy_from_slice and do away with our version.

However our version is very convenient in the sense that it doesn't
require the slices to be of the same size and does size management
for us.

What we can do, is replace the uses of unsafe with copy_from slice.

The problem is that now the name is confusing because we have two
things with the same name that behave differently. So rename them
read_at and write_at. The _at suffix makes it clear that we are
dealing with an offset.
