### PR TITLE
executor: change way we calculate shares

### DIFF
--- a/examples/cooperative_preempt.rs
+++ b/examples/cooperative_preempt.rs
@@ -1,5 +1,5 @@
 use futures::join;
-use scipio::{Latency, Local, LocalExecutorBuilder};
+use scipio::{Latency, Local, LocalExecutorBuilder, Shares};
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::time::{Duration, Instant};
@@ -29,10 +29,16 @@ fn main() {
     // then explicitly yield with later().
     let handle = LocalExecutorBuilder::new()
         .spawn(|| async move {
-            let tq1 =
-                Local::create_task_queue(1, Latency::Matters(Duration::from_millis(10)), "tq1");
-            let tq2 =
-                Local::create_task_queue(1, Latency::Matters(Duration::from_millis(10)), "tq1");
+            let tq1 = Local::create_task_queue(
+                Shares::default(),
+                Latency::Matters(Duration::from_millis(10)),
+                "tq1",
+            );
+            let tq2 = Local::create_task_queue(
+                Shares::default(),
+                Latency::Matters(Duration::from_millis(10)),
+                "tq1",
+            );
             let shared_value = Rc::new(RefCell::new(0u64));
 
             let value = shared_value.clone();

--- a/scipio/src/lib.rs
+++ b/scipio/src/lib.rs
@@ -137,6 +137,7 @@ mod multitask;
 mod networking;
 mod pollable;
 mod semaphore;
+mod shares;
 pub mod timer;
 
 pub use crate::executor::{
@@ -145,6 +146,7 @@ pub use crate::executor::{
 pub use crate::networking::*;
 pub use crate::pollable::Async;
 pub use crate::semaphore::Semaphore;
+pub use crate::shares::{Shares, SharesManager};
 pub use enclose::enclose;
 pub use scopeguard::defer;
 

--- a/scipio/src/shares.rs
+++ b/scipio/src/shares.rs
@@ -1,0 +1,96 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the
+// MIT/Apache-2.0 License, at your convenience
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//
+use core::fmt::Debug;
+use std::rc::Rc;
+use std::time::Duration;
+
+/// The SharesManager allows the user to implement dynamic shares for a [`TaskQueue`]
+///
+/// In terms of behavior, a [`TaskQueue`] with static shares is the same as a `SharesManager`
+/// managed queue that always return the same value. However this is a bit more expensive
+/// to compute because it needs to be reevaluated constantly.
+///
+/// The difference is akin to a constant versus variable in your favorite programming language.
+///
+/// [`TaskQueue`]: struct.LocalExecutor.html#method.create_task_queue
+pub trait SharesManager {
+    /// The amount of shares that this [`TaskQueue`] should receive in the next adjustment period
+    ///
+    /// [`TaskQueue`]: struct.LocalExecutor.html#method.create_task_queue
+    fn shares(&self) -> usize;
+
+    /// How often to recompute the amount of shares for this [`TaskQueue`]
+    ///
+    /// [`TaskQueue`]: struct.LocalExecutor.html#method.create_task_queue
+    fn adjustment_period(&self) -> Duration {
+        Duration::from_millis(250)
+    }
+}
+
+impl Debug for dyn SharesManager {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "Shares Manager: adjusting every {:#?}. Now: {}",
+            self.adjustment_period(),
+            self.shares()
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+/// Represents how many shares a [`TaskQueue`] should receive.
+///
+/// Scipio's scheduler doesn't work with priorities, but rather shares. That means
+/// that if there is only one active task queue in the system, it will always receive
+/// 100 % of the resources.
+///
+/// As soon as two or more task queues are active resources will be split between them
+/// proportionally to their shares: a queue with more shares will receive more resources.
+///
+/// Be careful when trying to reason about percentages of utilization as they will depend
+/// on the active task queues (The percentage of resources assigned to a task queue should be close to
+/// `shares(i) / sum(shares(i) for i in t)`)
+///
+/// For example, if all task queues have 1000 shares (the default), when two of them are active
+/// they will have each 50% of the resources. As soon as a third one activates, each now has
+/// 33%.
+///
+/// This can be far off if there are other heavy processes competing for resources with
+/// your application in a way that scipio can't see. For best results you should consider
+/// dedicating CPUs and storage devices to your application.
+///
+/// Shares are enforced by the system to be between 1 and 1000. So if all [`TaskQueue`]s want
+/// maximum resources they should all get similar fractions. It is not possible for a [`TaskQueue`]
+/// to say it wants to use more than the others: it is only possible for the other task queues to
+/// say they are okay with using less (by reducing their shares)
+///
+/// [`TaskQueue`]: struct.LocalExecutor.html#method.create_task_queue
+pub enum Shares {
+    /// Static shares never change over the course of a lifetime of the application, therefore they
+    /// never have to be recomputed
+    Static(usize),
+    /// Dynamic shares can change and are periodically recomputed.
+    Dynamic(Rc<dyn SharesManager>),
+}
+
+impl Default for Shares {
+    fn default() -> Self {
+        Shares::Static(1000)
+    }
+}
+
+impl Shares {
+    pub(crate) fn reciprocal_shares(&self) -> u64 {
+        let shares = match self {
+            Shares::Static(shares) => *shares,
+            Shares::Dynamic(bm) => bm.shares(),
+        };
+        let shares = std::cmp::max(shares, 1);
+        let shares = std::cmp::min(shares, 1000);
+        (1u64 << 22) / (shares as u64)
+    }
+}

--- a/scipio/src/timer/timer_impl.rs
+++ b/scipio/src/timer/timer_impl.rs
@@ -224,12 +224,12 @@ impl<T: 'static> TimerActionOnce<T> {
     /// # Examples
     ///
     /// ```
-    /// use scipio::{LocalExecutorBuilder, Local, Latency};
+    /// use scipio::{LocalExecutorBuilder, Local, Latency, Shares};
     /// use scipio::timer::TimerActionOnce;
     /// use std::time::Duration;
     ///
     /// let handle = LocalExecutorBuilder::new().spawn(|| async move {
-    ///     let tq = Local::create_task_queue(1, Latency::NotImportant, "test");
+    ///     let tq = Local::create_task_queue(Shares::default(), Latency::NotImportant, "test");
     ///     let action = TimerActionOnce::do_in_into(Duration::from_millis(100), async move {
     ///         println!("Executed once");
     ///     }, tq).unwrap();
@@ -304,12 +304,12 @@ impl<T: 'static> TimerActionOnce<T> {
     /// # Examples
     ///
     /// ```
-    /// use scipio::{LocalExecutorBuilder, Local, Latency};
+    /// use scipio::{LocalExecutorBuilder, Local, Latency, Shares};
     /// use scipio::timer::TimerActionOnce;
     /// use std::time::{Instant, Duration};
     ///
     /// let handle = LocalExecutorBuilder::new().spawn(|| async move {
-    ///     let tq = Local::create_task_queue(1, Latency::NotImportant, "test");
+    ///     let tq = Local::create_task_queue(Shares::default(), Latency::NotImportant, "test");
     ///     let when = Instant::now().checked_add(Duration::from_millis(100)).unwrap();
     ///     let action = TimerActionOnce::do_at_into(when, async move {
     ///         println!("Executed once");
@@ -491,12 +491,12 @@ impl TimerActionRepeat {
     /// # Examples
     ///
     /// ```no_run
-    /// use scipio::{LocalExecutorBuilder, Latency, Local};
+    /// use scipio::{LocalExecutorBuilder, Latency, Local, Shares};
     /// use scipio::timer::TimerActionRepeat;
     /// use std::time::Duration;
     ///
     /// let handle = LocalExecutorBuilder::new().spawn(|| async move {
-    ///     let tq = Local::create_task_queue(1, Latency::NotImportant, "test");
+    ///     let tq = Local::create_task_queue(Shares::default(), Latency::NotImportant, "test");
     ///     let action = TimerActionRepeat::repeat_into(|| async move {
     ///         println!("Execute this!");
     ///         Some(Duration::from_millis(100))


### PR DESCRIPTION
This will make it slightly easier to implement controllers: shares
are not either static or dynamic. Static shares work similarly to
a const variable (we can optimize because we know they never change)
whereas dynamic shares may change with time.

The methods to set and get shares are gone from visible API. Tests
are also added to make sure that the scheduler is working as intended.

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[x] I have added unit tests to the code I am submitting
[x] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
[x] The new code I am adding is formatted using `rustfmt`
