### PR TITLE
Fix use after free during cancellation

### DIFF
--- a/scipio/src/sys/uring.rs
+++ b/scipio/src/sys/uring.rs
@@ -1010,11 +1010,14 @@ mod tests {
             (source, op)
         }
 
+        let (fast, op) = timeout_source(50);
+        queue_standard_request!(reactor, &fast, op);
+
         let (slow, op) = timeout_source(150);
         queue_standard_request!(reactor, &slow, op);
 
-        let (fast, op) = timeout_source(50);
-        queue_standard_request!(reactor, &fast, op);
+        let (lethargic, op) = timeout_source(300);
+        queue_standard_request!(reactor, &lethargic, op);
 
         let start = Instant::now();
         let mut wakers = Vec::new();
@@ -1022,9 +1025,11 @@ mod tests {
         let elapsed_ms = start.elapsed().as_millis();
         assert!(50 <= elapsed_ms && elapsed_ms < 100);
 
+        drop(slow); // Cancel this one.
+
         let mut wakers = Vec::new();
         reactor.wait(&mut wakers, None, None).unwrap();
         let elapsed_ms = start.elapsed().as_millis();
-        assert!(150 <= elapsed_ms && elapsed_ms < 200);
+        assert!(300 <= elapsed_ms && elapsed_ms < 350);
     }
 }

--- a/scipio/src/sys/uring.rs
+++ b/scipio/src/sys/uring.rs
@@ -209,13 +209,18 @@ where
             return Some(());
         }
 
-        // Will be None if it was cancelled while in-flight.
-        if let Some(src) = consume_source(value.user_data()) {
+        let src = consume_source(value.user_data());
+
+        let result = value.result();
+        let was_cancelled =
+            matches!(&result, Err(err) if err.raw_os_error() == Some(libc::ECANCELED));
+
+        if !was_cancelled {
             let source = mut_source(&src);
 
             if try_process(source).is_none() {
                 let mut w = source.wakers.borrow_mut();
-                w.result = Some(value.result());
+                w.result = Some(result);
                 wakers.append(&mut w.waiters);
             }
         }
@@ -258,36 +263,19 @@ fn peek_source(id: u64) -> Rc<UnsafeCell<InnerSource>> {
     })
 }
 
-fn consume_source(id: u64) -> Option<Rc<UnsafeCell<InnerSource>>> {
+fn consume_source(id: u64) -> Rc<UnsafeCell<InnerSource>> {
     SOURCE_MAP.with(|x| {
         let mut map = x.borrow_mut();
-        if let Some(source) = map.map.remove(&id) {
-            let mut s = mut_source(&source);
-            s.id = None;
-            s.queue = None;
-            return Some(source);
-        }
-        None
+        let source = map.map.remove(&id).unwrap();
+        let mut s = mut_source(&source);
+        s.id = None;
+        s.queue = None;
+        source
     })
 }
 
 pub(crate) fn cancel_source(id: u64, queue: ReactorQueue) {
-    // This may happen during teardown of the system itself, in which
-    // case the thread local may be gone. That's fine because in that case
-    // the ring is gone
-    SOURCE_MAP
-        .try_with(|x| {
-            let mut map = x.borrow_mut();
-            // This is synchronous so if we were passed an id, it exists.
-            // Otherwise we panic. consume_source is different because it runs
-            // asynchronously when the ring returns. If we don't find and Id here
-            // that means that someone called drop() inside the io_uring poller which
-            // is totally illegal.
-            map.map.remove(&id).unwrap();
-            let mut q = queue.borrow_mut();
-            q.cancel_request(id);
-        })
-        .ok();
+    queue.borrow_mut().cancel_request(id);
 }
 
 #[derive(Debug)]
@@ -311,7 +299,14 @@ impl UringQueueState {
         match found {
             Some(idx) => {
                 self.submissions.remove(idx);
+                // We never submitted the request, so it's safe to consume
+                // source here -- kernel didn't see our buffers.
+                consume_source(id);
             }
+            // We are cancelling this request, but it is already submitted.
+            // This means that the kernel might be using the buffers right
+            // now, so we delay `consume_source` until we consume the
+            // corresponding event from the completion queue.
             None => self.cancellations.push_back(UringDescriptor {
                 args: UringOpDescriptor::Cancel(id),
                 fd: -1,

--- a/scipio/src/sys/uring.rs
+++ b/scipio/src/sys/uring.rs
@@ -237,7 +237,7 @@ struct SourceMap {
 impl SourceMap {
     fn new() -> RefCell<Self> {
         RefCell::new(Self {
-            id: 0,
+            id: 1,
             map: HashMap::new(),
         })
     }


### PR DESCRIPTION
### What does this PR do?

Fix use after free due to overly eager `Source::drop` (see commit message for the details). 

### Additional Notes

@glommer I am much less confident in this PR than usual. It would be nice to be able to actually trigger this condition in tests, but this doesn't seem to easy -- we need two ~~parallel syscalls~~ concurrent io_uring requests, one of which finishes fast, and the other doesn't finish. I wonder if we should add some kind of "mock" / "strace" capability, so that it is easy to fake syscalls going via uring. Might be useful for fault injection as well. 

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
[x] The new code I am adding is formatted using `rustfmt`
