### PR TITLE
Scipio controllers: deadline queue

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -19,3 +19,4 @@ rlimit,https://crates.io/crates/rlimit,MIT,Nugine
 lazy-static,https://crates.io/crates/lazy_static,MIT/Apache-2.0,Marvin Löbel
 scopeguard,https://crates.io/crates/scopeguard,MIT/Apache-2.0,bluss
 pin-project-lite:https://crates.io/crates/pin-project-lite,MIT/Apache-2.0,Taiki Endo
+log,https://crates.io/crates/log,MIT/Apache-2.0/The Rust Project Developers

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dev-dependencies]
 futures = "0.3.5"
+ansi_term = "0.12.1"
 scipio = { version = "0.1.0", path = "../scipio" }
 
 [[example]]
@@ -27,3 +28,7 @@ path = "defer.rs"
 [[example]]
 name = "cooperative_preempt"
 path = "cooperative_preempt.rs"
+
+[[example]]
+name = "deadline"
+path = "deadline_writer.rs"

--- a/examples/deadline_writer.rs
+++ b/examples/deadline_writer.rs
@@ -1,0 +1,208 @@
+use ansi_term::{Colour, Style};
+use scipio::controllers::{DeadlineQueue, DeadlineSource};
+use scipio::{Latency, Local, LocalExecutorBuilder, Shares, Task, TaskQueueHandle};
+use std::cell::Cell;
+use std::future::Future;
+use std::io;
+use std::pin::Pin;
+use std::rc::Rc;
+use std::time::{Duration, Instant};
+
+fn burn_cpu(dur: Duration) {
+    let now = Instant::now();
+    while now.elapsed() < dur {}
+}
+
+struct IntWriter {
+    deadline: Duration,
+    start: Instant,
+    count_target: usize,
+    count: Cell<usize>,
+    next_print: Cell<Duration>,
+    count_at_last_print: Cell<usize>,
+
+    last_tq_runtime: Cell<Duration>,
+    last_ex_runtime: Cell<Duration>,
+}
+
+impl IntWriter {
+    fn new(count_target: usize, deadline: Duration) -> Rc<IntWriter> {
+        Rc::new(IntWriter {
+            start: Instant::now(),
+            deadline,
+            count_target,
+            count: Cell::new(0),
+            next_print: Cell::new(Duration::from_secs(1)),
+            count_at_last_print: Cell::new(0),
+            last_tq_runtime: Cell::new(Duration::from_nanos(0)),
+            last_ex_runtime: Cell::new(Duration::from_nanos(0)),
+        })
+    }
+
+    async fn write_int(&self) -> Duration {
+        let my_handle = Local::current_task_queue();
+
+        loop {
+            let me = self.count.get();
+            let elapsed = self.start.elapsed();
+            if me >= self.count_target {
+                return elapsed;
+            }
+            self.count.set(me + 1);
+            if elapsed > self.next_print.get() {
+                let tq_stats = Local::task_queue_stats(my_handle).unwrap();
+
+                let tq_runtime = tq_stats.runtime();
+                let tq_delta = tq_runtime - self.last_tq_runtime.get();
+                let ex_runtime = Local::executor_stats().total_runtime();
+                let ex_delta = ex_runtime - self.last_ex_runtime.get();
+
+                let ratio = self.count.get() as f64 / self.count_target as f64 * 100.0;
+                let intratio = self.count.get() - self.count_at_last_print.get();
+
+                let cpuratio = 100.0 * tq_delta.as_secs_f64() / ex_delta.as_secs_f64();
+
+                println!(
+                    "{}: Wrote {} ({}%), {:.0} int/s, scheduler shares: {} , {:.2} % CPU",
+                    Colour::Blue.paint(format!("{}s", elapsed.as_secs())),
+                    self.count.get(),
+                    Style::new().bold().paint(format!("{:.0}", ratio)),
+                    intratio,
+                    Style::new()
+                        .bold()
+                        .paint(tq_stats.current_shares().to_string()),
+                    cpuratio
+                );
+                self.next_print
+                    .set(self.next_print.get() + Duration::from_secs(1));
+                self.count_at_last_print.set(self.count.get());
+                self.last_tq_runtime.set(tq_runtime);
+                self.last_ex_runtime.set(ex_runtime);
+            }
+
+            burn_cpu(Duration::from_micros(500));
+            Local::later().await;
+        }
+    }
+}
+
+impl DeadlineSource for IntWriter {
+    type Output = Duration;
+
+    fn expected_duration(&self) -> Duration {
+        self.deadline
+    }
+
+    fn action(&self) -> Pin<Box<dyn Future<Output = Duration> + '_>> {
+        Box::pin(self.write_int())
+    }
+
+    fn total_units(&self) -> u64 {
+        self.count_target as _
+    }
+
+    fn processed_units(&self) -> u64 {
+        self.count.get() as _
+    }
+}
+
+fn competing_cpu_hog(
+    stop: Rc<Cell<bool>>,
+    cpuhog_tq: TaskQueueHandle,
+) -> scipio::task::JoinHandle<(), ()> {
+    Local::local_into(
+        async move {
+            while !stop.get() {
+                burn_cpu(Duration::from_micros(500));
+                Local::later().await;
+            }
+        },
+        cpuhog_tq,
+    )
+    .unwrap()
+    .detach()
+}
+
+async fn static_writer(how_many: usize, shares: usize, cpuhog_tq: TaskQueueHandle) -> Duration {
+    let name = format!("shares-{}", shares);
+    let tq = Local::create_task_queue(Shares::Static(shares), Latency::NotImportant, &name);
+
+    let stop = Rc::new(Cell::new(false));
+    let hog = competing_cpu_hog(stop.clone(), cpuhog_tq);
+
+    let writer = Task::local_into(
+        async move {
+            // Last parameter is bogus outside the queue, but we're just reusing the same writer
+            let test = IntWriter::new(how_many, Duration::from_secs(0));
+            test.write_int().await
+        },
+        tq,
+    )
+    .unwrap()
+    .detach();
+
+    let res = writer.await.unwrap();
+    stop.set(true);
+    hog.await.unwrap();
+    res
+}
+
+// FIXME: this is just much simpler, but in a standard scipio program you should avoid blocking.
+// This has actually some nasty effects in that all the blocking time is accounted in this task
+// queue. As soon as we have a good buffered file implementation we should come here and fix this
+// so nobody thinks lowly of us.
+fn blocking_read_int() -> Result<usize, <usize as std::str::FromStr>::Err> {
+    let mut buffer = String::new();
+    io::stdin().read_line(&mut buffer).unwrap();
+    let buf = buffer.trim();
+    buf.parse::<usize>()
+}
+
+fn main() {
+    let handle = LocalExecutorBuilder::new().pin_to_cpu(0)
+        .spawn(|| async move {
+
+            let cpuhog_tq = Local::create_task_queue(Shares::Static(1000), Latency::NotImportant, "cpuhog");
+
+            println!("{}", Style::new().bold().paint("Welcome to the Deadline Writer example"));
+            println!("In this example we will write a sequence of integers to a variable, busy looping for 500us after each write");
+            println!("While we do that, another CPU hog will be running constantly in a different TaskQueue");
+            println!("For {} results, this test is pinned to your CPU0. Make sure nothing else of significance is running there. You should be able to see it at 100% at all times!",
+                     Style::new().bold().paint("best"));
+
+            println!("\n\nPlease tell me how many integers you would like to write");
+            let to_write = blocking_read_int().unwrap();
+            println!("Ok, now let's write {} integers with both the writer and the CPU hog having the same priority", Colour::Blue.paint(to_write.to_string()));
+            let dur = static_writer(to_write, 1000, cpuhog_tq).await;
+            println!("Finished writing in {}", Colour::Green.paint(format!("{:#.0?}", dur)));
+            println!("This was using {} shares, and short of reducing the priority of the CPU hog. {}",
+                Colour::Green.paint("1000"), Style::new().bold().paint("This is as fast as we can do!"));
+            println!("With {} shares, this would have taken approximately {}", Colour::Green.paint("100"), Colour::Green.paint(format!("{:#.1?}", dur * 10)));
+            println!("With {} shares, this would have taken approximately {}. {}.", Colour::Green.paint("1"),
+                     Colour::Green.paint(format!("{:#.1?}", dur * 1000)), Style::new().bold().paint("Can't go any slower than that!"));
+
+            println!("\n\nLet's try the controlled process. How long would you like it to take? (seconds)");
+            println!("Keep in mind that very short processes will be inherently unstable because of the time the controller needs to adapt");
+            let mut duration = blocking_read_int().unwrap();
+
+            loop {
+                let stop = Rc::new(Cell::new(false));
+                let hog = competing_cpu_hog(stop.clone(), cpuhog_tq);
+                Local::later().await;
+
+                let deadline = DeadlineQueue::new("example", Duration::from_millis(250));
+                let test = IntWriter::new(to_write, Duration::from_secs(duration as u64));
+                let dur = deadline.push_work(test).await.unwrap();
+                println!("Finished writing in {}", Colour::Green.paint(format!("{:#.2?}", dur)));
+                stop.set(true);
+                hog.await.unwrap();
+                println!("If you want to try again tell me how long it should take this time, or press some non-number to exit");
+                duration = match blocking_read_int() {
+                    Ok(num) => num,
+                    Err(_) => break,
+                }
+            }
+        }).unwrap();
+
+    handle.join().unwrap();
+}

--- a/scipio/Cargo.toml
+++ b/scipio/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["asynchronous", "os"]
 readme = "README.md"
 
 [dependencies]
+log = "0.4"
 concurrent-queue = "1.1.2"
 futures-lite = "1.11.1"
 libc = "0.2.73"

--- a/scipio/src/controllers/deadline_queue.rs
+++ b/scipio/src/controllers/deadline_queue.rs
@@ -1,0 +1,637 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the
+// MIT/Apache-2.0 License, at your convenience
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+
+use crate::channels::local_channel::{self, LocalReceiver, LocalSender};
+use crate::task;
+use crate::{Latency, Local, Shares, SharesManager, TaskQueueHandle};
+use futures_lite::StreamExt;
+use log::warn;
+use std::cell::{Cell, RefCell};
+use std::collections::VecDeque;
+use std::fmt;
+use std::future::Future;
+use std::io;
+use std::pin::Pin;
+use std::rc::Rc;
+use std::time::{Duration, Instant};
+
+/// Items going into the [`DeadlineQueue`] must implement this trait.
+///
+/// It allows the [`DeadlineQueue`] to understand the progress and expectations
+/// of processing this item
+///
+/// [`DeadlineQueue`]: struct.DeadlineQueue.html
+pub trait DeadlineSource {
+    /// What type is returned by the [`action`] method
+    ///
+    /// [`action`]: trait.DeadlineSource.html#method.action
+    type Output;
+
+    /// Returns a [`Duration`] indicating when we would like this operation to complete.
+    ///
+    /// It is calculated from the point of Queueing, not from the point in which the operation
+    /// starts.
+    fn expected_duration(&self) -> Duration;
+
+    /// The action to execute. Usually your struct will implement an async function that you want
+    /// to see completed at a particular deadline, and then the implementation of this would be:
+    ///
+    /// ```ignore
+    /// fn action(&self) -> Pin<Box<dyn Future<Output = io::Result<Duration>> + '_>> {
+    ///    Box::pin(self.my_action())
+    /// }
+    /// ```
+    fn action(&self) -> Pin<Box<dyn Future<Output = Self::Output> + '_>>;
+
+    /// The total amount of units to be processed.
+    ///
+    /// This could be anything you want:
+    /// * If you are flushing a file, this could indicate the size in bytes of the buffer
+    /// * If you are scanning an array, this could be the number of elements.
+    ///
+    /// As long as this quantity is consistent with [`processed_units`] the controllers should work.
+    ///
+    /// This need not be static. On the contrary: as you are filling a new buffer you can already
+    /// add it to the queue and increase its total units as the buffer is written to. This can
+    /// lead to smoother operation as opposed to just adding a lot of units at once.
+    ///
+    /// [`processed_units`]: trait.DeadlineSource.html#method.processed_units
+    fn total_units(&self) -> u64;
+
+    /// The amount of units that were already processed.
+    ///
+    /// The units should match the quantities specified in [`total_units`].
+    /// The more often the system is made aware of processed units, the smoother the
+    /// controller will be.
+    ///
+    /// For example, you can buffer all updates and just inform that processed_units == total_units
+    /// at the end of the process, but then the controller would be a step function.
+    ///
+    /// [`total_units`]: trait.DeadlineSource.html#method.total_units
+    fn processed_units(&self) -> u64;
+}
+
+impl<T> fmt::Debug for dyn DeadlineSource<Output = T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "DeadlineSource processed {} out of {}",
+            self.processed_units(),
+            self.total_units()
+        )
+    }
+}
+
+#[derive(Debug)]
+/// Allows the priority of the [`DeadlineQueue`] to be temporarily bumped.
+///
+/// The priority is bumped for as long as this object is alive. This is useful
+/// in situations where, despite having a deadline we may never want the priority
+/// to fall too low.
+///
+/// This could be because a user started watching the process, a shutdown sequence
+/// was initiated, etc.
+///
+/// [`DeadlineQueue`]: struct.DeadlineQueue.html
+pub struct PriorityBump<T> {
+    queue: Rc<InnerQueue<T>>,
+}
+
+impl<T> PriorityBump<T> {
+    fn new(queue: Rc<InnerQueue<T>>) -> PriorityBump<T> {
+        queue.min_shares.set(250);
+        PriorityBump { queue }
+    }
+}
+
+impl<T> Drop for PriorityBump<T> {
+    fn drop(&mut self) {
+        self.queue.min_shares.set(1);
+    }
+}
+
+type QueueItem<T> = Rc<dyn DeadlineSource<Output = T>>;
+
+#[derive(Debug)]
+struct InnerQueue<T> {
+    queue: RefCell<VecDeque<(Instant, QueueItem<T>)>>,
+    last_admitted: Cell<Instant>,
+
+    last_adjusted: Cell<Instant>,
+    last_shares: Cell<usize>,
+    accumulated_error: Cell<f64>,
+    adjustment_period: Duration,
+    last_error: Cell<f64>,
+    min_shares: Cell<usize>,
+}
+
+impl<T> SharesManager for InnerQueue<T> {
+    // PI controller for shares.
+    //
+    // We are not dealing with the derivative constant here: it is too risky given the generic
+    // nature of the processes under control.
+    //
+    // The variable we are controlling is the speed at which the units are processed.
+    // Also because we don't know what units are and different items in the queue may have
+    // different magnitudes we need to work with normalized units.
+    //
+    // The error is the difference between our effective speed and the desired speed:
+    //
+    //    e(t) = units_expected/delta_t -  units_processed/ delta_t,
+    //
+    //  and because we are normalizing:
+    //
+    //    e(t) = 1/delta_t * (1 - units_processed / units_expected)
+    //
+    //  The controller output is then:
+    //
+    //    u(t) = Kp * e(t) + Ki + Integral{0, t} e(t)
+    //
+    //  There are a couple of practical problems with that.
+    //
+    //  * The first is that the output of the controller would be zero if we there
+    //    is no error
+    //  * The second is that our integral term would accumulate errors that may not
+    //    be comparable as we accumulate artifacts of the delta_t calculation (as we'll
+    //    never in practice keep delta_t constant)
+    //
+    //  The way we'll solve this is by expressing an alternate error E(T) which is
+    //  essentially the integral of e(t) in time:
+    //
+    //    E(t) = 1 - units_processed / units_expected.
+    //
+    //  That is easy to compute, as it is essentially the total count of units for
+    //  all items in the queue, both processed and expected.
+    //
+    //  We can now express our output function as the derivative of U(t), the output
+    //  function for the integral of the error:
+    //
+    //    u(t) = d(U(t)) / dt = Kp * dE(t) /dt + Ki * E(t)
+    //
+    //  Now we are calculating how much shares should be added or removed to the
+    //  last output, and not how much the shares should be. It also eliminates any
+    //  dependency on time when calculating the error which increases resiliency.
+    fn shares(&self) -> usize {
+        let queue = self.queue.borrow();
+        let mut expected = 0.0;
+        let mut processed = 0.0;
+        let now = Instant::now();
+
+        for (exp, source) in queue.iter() {
+            let remaining_time = exp.saturating_duration_since(now);
+            let time_fraction =
+                1.0 - (remaining_time.as_secs_f64() / source.expected_duration().as_secs_f64());
+            if remaining_time.as_nanos() == 0 && now.saturating_duration_since(*exp).as_secs() > 5 {
+                // already too late, bump it up hard
+                self.last_shares.set(1000);
+                return 1000;
+            }
+            expected += source.total_units() as f64 * time_fraction;
+            processed += source.processed_units() as f64;
+        }
+
+        // so little time has passed we can't really make any useful prediction
+        if expected < 0.01 {
+            self.last_shares.set(1);
+            return 1;
+        }
+
+        let error = 1.0 - processed / expected;
+        let accumulated_error = self.accumulated_error.get();
+        let acc = accumulated_error + error;
+        self.accumulated_error.set(acc);
+        let delta_error = error - self.last_error.get();
+        self.last_error.set(error);
+
+        // How did we pick our constants:
+        //  * As with any stable PI controller we want the bulk of our gain to come from P.
+        //  * As we normalize the maximum error to 1 we know that the gain should be at most 1000
+        //  * physically, Ki can be expressed as Kp / Tau where Tau is a time constant, roughly
+        //    equivalent to how many periods need to pass for the integral term to generate the
+        //    same gain as the proportional term. We set that to 6 so the controller is not too
+        //    slugish, which is around 1.5 seconds on the default 250ms adjustment period.
+        //
+        //  We can then write X + X/6 = 1000, and solving for X we have the constants below
+        let kp = 850.0;
+        let ki = kp / 6.0;
+        let dshares = ki * error + kp * delta_error;
+
+        let mut shares = (dshares + self.last_shares.get() as f64) as isize;
+        shares = std::cmp::min(shares, 1000);
+        shares = std::cmp::max(shares, self.min_shares.get() as isize);
+        let shares = shares as usize;
+
+        self.last_shares.set(shares);
+        shares
+    }
+
+    fn adjustment_period(&self) -> Duration {
+        self.adjustment_period
+    }
+}
+
+impl<T> InnerQueue<T> {
+    fn new(adjustment_period: Duration) -> Self {
+        let now = Instant::now();
+        Self {
+            queue: RefCell::new(VecDeque::new()),
+            last_admitted: Cell::new(now),
+            last_adjusted: Cell::new(now),
+            last_shares: Cell::new(1),
+            accumulated_error: Cell::new(0.0),
+            adjustment_period,
+            last_error: Cell::new(0.0),
+            min_shares: Cell::new(1),
+        }
+    }
+
+    fn admit(&self, source: Rc<dyn DeadlineSource<Output = T>>) -> io::Result<()> {
+        let expiration = Instant::now()
+            .checked_add(source.expected_duration())
+            .ok_or_else(|| io::Error::from(io::ErrorKind::InvalidInput))?;
+        expiration
+            .checked_duration_since(self.last_admitted.get())
+            .ok_or_else(|| io::Error::from(io::ErrorKind::InvalidInput))?;
+        self.last_admitted.set(expiration);
+        let mut queue = self.queue.borrow_mut();
+        queue.push_back((expiration, source.clone()));
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+/// Scipio's scheduler is based on [`Shares`]: the more shares, the more resources the task
+/// will receive.
+///
+/// There are situations however in which we don't want shares to grow too high: for instance,
+/// a background process that is flushing a file to storage. If it were to run at full speed,
+/// it would rob us of precious resources that we'd rather dedicate to the rest of the application.
+///
+/// However we don't want it to to run too slowly either, as it may never complete.
+///
+/// The "right amount" of shares is not even application dependent: it is time dependent! As the
+/// load of the system changes, what is "too high" or "too low" changes too.
+///
+/// The `DeadlineQueue` uses a feedback loop controller, not unlike the ones in car's cruise
+/// controls to dynamically and automatically adjust shares so that the process is slowed down
+/// using as few resources as possible but still finishes before its deadline.
+///
+/// For example, you may want to flush a file and would like it to finish in 10min because you
+/// have an agent that copies files every 10 minutes. You name it!
+///
+/// Controlling processes is tricky and you should keep some things in mind for best results:
+///
+/// * Control loops have a set time. It takes a while for the system to stabilize so this is better
+///   suited for long processes (Deadline is much higher than the adjustment period)
+/// * Control loops add overhead, so setting the adjustment period too low may not be the best way
+///   to make sure that the dealine is much higher than the adjustment period =)
+/// * Control loops have *dead time*. In control theory, dead time is the time that passes
+///   between the application of the control decision and its effects being seen. In our case, the
+///   scheduler may not schedule us for a long time, especially if the shares are low.
+/// * Control loops work better the faster and smoother the response is. Let's use an example flushing a
+///   file: you may be moving data to the file internal buffers but they are not *flushed* to the
+///   media. When the data is finally flushed a giant bubble is inserted into the control loop. The
+///   characteristics of the system will radically change. Contract that for instance with O_DIRECT
+///   files, where writing to the file means writing to the media: smooth and fast feedback!
+///
+///   The moral of the story is:
+///    * do not use this with buffered files or other buffered sinks where the real physical response
+///      is delayed
+///    * do not set the adjustment period too low
+///    * do not use this very short lived processes.
+///
+/// To calculate the speed of the process, the needs of all elements in the queue are considered.
+///
+/// Let's say, for instance, that you queue items A, B and C, each with 10,000 units finishing
+/// respectively in 1, 2 and 3 minutes. From the point of view of the system, all units from A
+/// and B need to be flushed before C can start so that is taken into account: the system needs
+/// to set its speed to 10,000 points per minute so that the entire queue is flushed in 3
+/// minutes.
+pub struct DeadlineQueue<T> {
+    tq: TaskQueueHandle,
+    sender: LocalSender<Rc<dyn DeadlineSource<Output = T>>>,
+    responder: LocalReceiver<T>,
+    handle: task::join_handle::JoinHandle<(), ()>,
+    queue: Rc<InnerQueue<T>>,
+}
+
+impl<T: 'static> DeadlineQueue<T> {
+    /// Creates a new `DeadlineQueue` with a given `name` and `adjustment period`
+    ///
+    /// Internally the `DeadlineQueue` spawns a new task queue with dynamic shares
+    /// in which it will execute the tasks that were registered.
+    ///
+    /// # Examples
+    /// ```
+    /// use scipio::LocalExecutor;
+    /// use scipio::controllers::DeadlineQueue;
+    /// use std::time::Duration;
+    ///
+    /// let ex = LocalExecutor::make_default();
+    ///
+    /// ex.run(async {
+    ///     DeadlineQueue::<usize>::new("example", Duration::from_millis(250));
+    /// });
+    /// ```
+    pub fn new(name: &'static str, adjustment_period: Duration) -> DeadlineQueue<T> {
+        let queue = Rc::new(InnerQueue::new(adjustment_period));
+        // We could always dispatch into the latency queue, but since that effectively means
+        // putting requests in a different io_uring we'll avoid doing that unless the process
+        // is very sensitive. Because of dead time it wouldn't be a bad idea to even have a minimum
+        // here. But we'll just document it and leave it to the user.
+        let lat = {
+            if adjustment_period < Duration::from_millis(100) {
+                Latency::Matters(adjustment_period)
+            } else {
+                Latency::NotImportant
+            }
+        };
+
+        let tq = Local::create_task_queue(Shares::Dynamic(queue.clone()), lat, name);
+        let (sender, mut receiver): (LocalSender<QueueItem<T>>, LocalReceiver<QueueItem<T>>) =
+            local_channel::new_bounded(1);
+
+        let (response_sender, responder): (LocalSender<T>, LocalReceiver<T>) =
+            local_channel::new_bounded(1);
+
+        let handle = Local::local_into(
+            async move {
+                let response = Rc::new(response_sender);
+                while let Some(request) = receiver.next().await {
+                    let res = request.action().await;
+                    if response.send(res).await.is_err() {
+                        warn!("receiver channel broken!");
+                        break;
+                    }
+                }
+            },
+            tq,
+        )
+        .unwrap()
+        .detach();
+
+        DeadlineQueue {
+            tq,
+            sender,
+            responder,
+            handle,
+            queue,
+        }
+    }
+
+    /// Pushes a new [`DeadlineSource`] into this queue
+    ///
+    /// Returns an [`io::Result`] wrapping the result of the operation.
+    ///
+    /// # Examples:
+    ///
+    /// ```
+    /// use scipio::LocalExecutor;
+    /// use scipio::controllers::{DeadlineQueue, DeadlineSource};
+    /// use std::time::Duration;
+    /// use futures_lite::future::ready;
+    /// use std::io;
+    /// use std::pin::Pin;
+    /// use futures_lite::Future;
+    /// use std::rc::Rc;
+    ///
+    /// struct Example {
+    /// }
+    ///
+    /// impl DeadlineSource for Example {
+    ///     type Output = usize;
+    ///
+    ///     fn expected_duration(&self) -> Duration {
+    ///        Duration::from_secs(1)
+    ///     }
+    ///
+    ///     fn action(&self) -> Pin<Box<dyn Future<Output = Self::Output> + '_>> {
+    ///        Box::pin(ready(1))
+    ///     }
+    ///
+    ///     fn total_units(&self) -> u64 {
+    ///        1
+    ///     }
+    ///
+    ///     fn processed_units(&self) -> u64 {
+    ///        1
+    ///     }
+    /// }
+    ///
+    /// let ex = LocalExecutor::make_default();
+    ///
+    /// ex.run(async {
+    ///     let mut queue = DeadlineQueue::new("example", Duration::from_millis(250));
+    ///     let res = queue.push_work(Rc::new(Example {})).await;
+    ///     assert_eq!(res.unwrap(), 1);
+    /// });
+    /// ```
+    ///
+    pub async fn push_work(&self, source: Rc<dyn DeadlineSource<Output = T>>) -> io::Result<T> {
+        self.queue.admit(source.clone())?;
+        self.sender.send(source.clone()).await?;
+        self.responder.recv().await.ok_or_else(|| {
+            io::Error::new(io::ErrorKind::Other, "no response from response channel")
+        })
+    }
+
+    /// Temporarily bumps the priority of this DeadlineQueue
+    ///
+    /// The bump happens by making sure that the shares never fall below
+    /// a minimum (250). If the output of the controller is already higher than that
+    /// then this has no effect.
+    pub fn bump_priority(&self) -> PriorityBump<T> {
+        PriorityBump::new(self.queue.clone())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::enclose;
+    use crate::timer::{Timer, TimerActionRepeat};
+
+    struct DeadlineSourceTest {
+        duration: Duration,
+        total_units: usize,
+        processed_units: Cell<usize>,
+    }
+
+    impl DeadlineSourceTest {
+        fn new(duration: Duration, total_units: usize) -> Rc<Self> {
+            Rc::new(Self {
+                duration,
+                total_units,
+                processed_units: Cell::new(0),
+            })
+        }
+        async fn wait(&self) -> usize {
+            Timer::new(self.duration).await;
+            0
+        }
+    }
+
+    impl DeadlineSource for DeadlineSourceTest {
+        type Output = usize;
+
+        fn expected_duration(&self) -> Duration {
+            self.duration
+        }
+
+        fn action(&self) -> Pin<Box<dyn Future<Output = Self::Output> + '_>> {
+            Box::pin(self.wait())
+        }
+
+        fn total_units(&self) -> u64 {
+            self.total_units as _
+        }
+
+        fn processed_units(&self) -> u64 {
+            self.processed_units.get() as _
+        }
+    }
+
+    #[test]
+    fn deadline_queue_does_not_accept_non_monotonic_durations() {
+        test_executor!(async move {
+            let queue = Rc::new(DeadlineQueue::new("example", Duration::from_millis(1)));
+            let tq = Local::local(enclose! { (queue) async move {
+                let test = DeadlineSourceTest::new(Duration::from_secs(2 as u64), 1);
+                let res = queue.push_work(test).await.unwrap();
+                assert_eq!(res, 0);
+            }})
+            .detach();
+
+            Timer::new(Duration::from_millis(1)).await;
+            let test = DeadlineSourceTest::new(Duration::from_secs(1 as u64), 1);
+            match queue.push_work(test).await {
+                Err(x) => assert_eq!(x.kind(), io::ErrorKind::InvalidInput),
+                Ok(_) => panic!("should have failed"),
+            }
+            tq.await;
+        });
+    }
+
+    #[test]
+    fn deadline_queue_behaves_well_with_zero_total_units() {
+        test_executor!(async move {
+            let queue = Rc::new(DeadlineQueue::<usize>::new(
+                "example",
+                Duration::from_millis(1),
+            ));
+            let test = DeadlineSourceTest::new(Duration::from_secs(1 as u64), 0);
+            let res = queue.push_work(test).await.unwrap();
+            assert_eq!(res, 0);
+        });
+    }
+
+    #[test]
+    fn deadline_queue_behaves_well_if_we_process_too_much() {
+        test_executor!(async move {
+            let queue = Rc::new(DeadlineQueue::<usize>::new(
+                "example",
+                Duration::from_millis(1),
+            ));
+            let test = DeadlineSourceTest::new(Duration::from_secs(1 as u64), 1000);
+            let tq = Local::local(enclose! { (queue, test) async move {
+                let res = queue.push_work(test).await.unwrap();
+                assert_eq!(res, 0);
+            }})
+            .detach();
+
+            Timer::new(Duration::from_millis(2)).await;
+            test.processed_units.set(1000 * 1000);
+            Timer::new(Duration::from_millis(2)).await;
+            assert_eq!(queue.queue.shares(), 1);
+            tq.await;
+        });
+    }
+
+    #[test]
+    fn deadline_queue_shares_increase_if_we_dont_process() {
+        test_executor!(async move {
+            let queue = Rc::new(DeadlineQueue::<usize>::new(
+                "example",
+                Duration::from_millis(1),
+            ));
+            let test = DeadlineSourceTest::new(Duration::from_secs(1 as u64), 1000);
+            let tq = Local::local(enclose! { (queue, test) async move {
+                let res = queue.push_work(test).await.unwrap();
+                assert_eq!(res, 0);
+            }})
+            .detach();
+
+            Timer::new(Duration::from_millis(900)).await;
+            assert!(queue.queue.shares() > 800);
+            tq.await;
+        });
+    }
+
+    #[test]
+    fn deadline_queue_shares_ok_if_we_process_smoothly() {
+        test_executor!(async move {
+            let queue = Rc::new(DeadlineQueue::<usize>::new(
+                "example",
+                Duration::from_millis(10),
+            ));
+            let test = DeadlineSourceTest::new(Duration::from_secs(1 as u64), 1000);
+            let tq = Local::local(enclose! { (queue, test) async move {
+                let res = queue.push_work(test).await.unwrap();
+                assert_eq!(res, 0);
+            }})
+            .detach();
+
+            let start = Instant::now();
+            let last_shares = Rc::new(Cell::new(0));
+            let action = TimerActionRepeat::repeat(move || {
+                enclose! { (queue, test, last_shares) async move {
+                    let elapsed = start.elapsed().as_millis();
+                    let shares = queue.queue.shares();
+                    let old = last_shares.replace(shares) as isize;
+                    if elapsed > 500 {
+                        let diff = old - shares as isize;
+                        assert!(diff.abs() < 200, format!("Found diff: {}", diff));
+                    }
+                    if test.processed_units.replace(elapsed as usize) < 1000 {
+                        Some(Duration::from_millis(50))
+                    } else {
+                        None
+                    }
+                }}
+            });
+            tq.await;
+            action.join().await;
+        });
+    }
+
+    #[test]
+    fn deadline_queue_second_queued_item_increases_slope() {
+        test_executor!(async move {
+            let queue = Rc::new(DeadlineQueue::new("example", Duration::from_millis(1)));
+            let tq = Local::local(enclose! { (queue) async move {
+                let test = DeadlineSourceTest::new(Duration::from_secs(1 as u64), 1);
+                let res = queue.push_work(test).await.unwrap();
+                assert_eq!(res, 0);
+            }})
+            .detach();
+
+            Timer::new(Duration::from_millis(2)).await;
+            let shares_first = queue.queue.shares();
+            let tq2 = Local::local(enclose! { (queue) async move {
+                let test = DeadlineSourceTest::new(Duration::from_secs(1 as u64), 1000);
+                let res = queue.push_work(test).await.unwrap();
+                assert_eq!(res, 0);
+            }})
+            .detach();
+
+            Timer::new(Duration::from_millis(2)).await;
+            let shares_second = queue.queue.shares();
+            // The second element that we push should rush the first.
+            assert!(shares_second >= shares_first * 20);
+            tq.await;
+            tq2.await;
+        });
+    }
+}

--- a/scipio/src/controllers/mod.rs
+++ b/scipio/src/controllers/mod.rs
@@ -1,0 +1,14 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the
+// MIT/Apache-2.0 License, at your convenience
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//! scipio::controllers provide helpful constructs to automatically control the
+//! shares, and in consequence the proportion of resources, that a particular process
+//! uses.
+//!
+//! It implements data structures with embedded controllers derived from work in
+//! control theory like the [`PID controller`].
+//!
+//! [`PID controller`]: https://en.wikipedia.org/wiki/PID_controller
+mod deadline_queue;
+pub use self::deadline_queue::*;

--- a/scipio/src/lib.rs
+++ b/scipio/src/lib.rs
@@ -131,6 +131,7 @@ macro_rules! make_shared_var_mut {
 }
 
 pub mod channels;
+pub mod controllers;
 mod error;
 mod executor;
 pub mod io;


### PR DESCRIPTION
### What does this PR do?

This PR adds Scipio's first controller. A controller is an entity that can dynamically and automatically adjust shares of a task queue lower or higher so that the tasks in that task queue proceed accordingly to some user-defined criteria.

The first of such controllers is the DeadlineQueue: It is a version of a work queue, in which each element is given a deadline. The goal of the controller is to minimize the impact of running the work queue by reducing shares as much as possible so long as each element finishes within its deadline

It comes with an interactive example you can play with!

### Motivation

Process controllers were used extensively in Scylla to control background processes such as buffer flushes and LSM compactions, making sure that the database had stable latencies throughout its operation. However, those were done
at the application level (Scylla), as opposed to the framework level (seastar)

The challenge I set myself to solve for Scipio was to do this in a generic enough fashion so that it can live in the library and
be easily consumable by application developers.

This means a considerable amount of effort will be poured into wrapping up the controllers in a series of APIs that makes sense for general purpose use.

The first such API is the DeadlineQueue: a workqueue-like structure that queues items implementing a particular trait. (DeadlineSource)

Items in that queue tell the controller how much work they are supposed to do (in user-defined units) and how how much work they have done already. Items execute sequentially. The controller does the rest.
