### PR TITLE
export executor statistics

### DIFF
--- a/scipio/src/lib.rs
+++ b/scipio/src/lib.rs
@@ -141,7 +141,8 @@ mod shares;
 pub mod timer;
 
 pub use crate::executor::{
-    LocalExecutor, LocalExecutorBuilder, QueueNotFoundError, Task, TaskQueueHandle,
+    ExecutorStats, LocalExecutor, LocalExecutorBuilder, QueueNotFoundError, Task, TaskQueueHandle,
+    TaskQueueStats,
 };
 pub use crate::networking::*;
 pub use crate::pollable::Async;


### PR DESCRIPTION
This patch allows applications to consume statistics about the internal
state of the Executors and its task queues.

We won't go into the business of exporting them anywhere else: that is
left for the applications to deal with.
