### PR TITLE
standardize on futures_lite

### DIFF
--- a/scipio/Cargo.toml
+++ b/scipio/Cargo.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 
 [dependencies]
 concurrent-queue = "1.1.2"
-futures-lite = "0.1.9"
+futures-lite = "1.11.1"
 libc = "0.2.73"
 socket2 = { version = "0.3.12", features = ["pair", "unix"] }
 iou = { git = "https://github.com/glommer/iou", tag = "scipio-2020-09-11" }
@@ -25,8 +25,10 @@ aligned_alloc = "0.1"
 bitmaps = "2.1.0"
 typenum = "1.12"
 scoped-tls = "1.0.0"
-futures = "0.3.5"
 rlimit = "0.3.0"
 lazy_static = "1.4.0"
 enclose = "1.1.8"
 scopeguard = "1.1.0"
+
+[dev-dependencies]
+futures = "0.3.5"


### PR DESCRIPTION
This patch removes "futures" from Cargo.toml, meaning it won't be possible
anymore to use it by accident in our implementations.

There are still a lot of users in test code, so for now we'll leave it
in dev-dependencies so we don't need to rush to convert.

Outside of testing, really the only contentious use was in file_stream.
