### PR TITLE
fix memory leak on executor creation.

### DIFF
--- a/scipio/src/executor.rs
+++ b/scipio/src/executor.rs
@@ -534,6 +534,7 @@ impl LocalExecutor {
     fn init(&mut self) -> io::Result<()> {
         let queues = self.queues.clone();
         let index = 0;
+        let queues_weak = Rc::downgrade(&queues);
 
         let io_requirements = IoRequirements::new(Latency::NotImportant, 0);
         self.queues.borrow_mut().available_executors.insert(
@@ -544,7 +545,8 @@ impl LocalExecutor {
                 Shares::Static(1000),
                 io_requirements,
                 move || {
-                    let mut queues = queues.borrow_mut();
+                    let q = queues_weak.upgrade().unwrap();
+                    let mut queues = q.borrow_mut();
                     queues.maybe_activate(index);
                 },
             ),


### PR DESCRIPTION
Classic circular reference. The notify function takes a copy of
the shared pointer "queues", but the notify function itself is saved
inside a task queue (which lives inside queues).

Use weak pointers to remove the circularity.

Fixes #110

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
[] The new code I am adding is formatted using `rustfmt`
