### PR TITLE
Strongly-typed state transition for source

### DIFF
--- a/scipio/src/sys/mod.rs
+++ b/scipio/src/sys/mod.rs
@@ -3,7 +3,7 @@
 //
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
 //
-use std::cell::{Cell, RefCell};
+use std::cell::RefCell;
 use std::convert::TryFrom;
 use std::ffi::CString;
 use std::mem::ManuallyDrop;
@@ -185,54 +185,40 @@ impl From<Duration> for TimeSpec64 {
     }
 }
 
-/// Tasks interested in events on a source.
-#[derive(Debug)]
-pub(crate) struct Wakers {
-    /// Raw result of the operation.
-    pub(crate) result: Option<io::Result<usize>>,
-
-    /// Tasks waiting for the next event.
-    pub(crate) waiters: Vec<Waker>,
-}
-
-impl Wakers {
-    pub(crate) fn new() -> Self {
-        Wakers {
-            result: None,
-            waiters: Vec::new(),
-        }
-    }
-}
-
 /// A registered source of I/O events.
+#[derive(Debug)]
 pub struct InnerSource {
     /// Raw file descriptor on Unix platforms.
     raw: RawFd,
-
-    /// Tasks interested in events on this source.
-    wakers: RefCell<Wakers>,
 
     source_type: RefCell<SourceType>,
 
     io_requirements: IoRequirements,
 
-    enqueued: Cell<Option<EnqueuedSource>>,
+    state: RefCell<SourceState>,
 }
 
-pub struct EnqueuedSource {
-    pub(crate) id: SourceId,
-    pub(crate) queue: ReactorQueue,
+#[derive(Debug)]
+enum SourceState {
+    /// The `Source` starts in this state.
+    NotQueued,
+    /// The source was queued into the ring.
+    Queued(QueueInfo),
+    /// The source was completed with the specified result.
+    Ready {
+        /// Raw result of the operation.
+        result: io::Result<usize>,
+    },
+    /// The source finishes in this state after the result is consumed.
+    Consumed,
 }
 
-impl fmt::Debug for InnerSource {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("InnerSource")
-            .field("raw", &self.raw)
-            .field("wakers", &self.wakers)
-            .field("source_type", &self.source_type)
-            .field("io_requirements", &self.io_requirements)
-            .finish()
-    }
+#[derive(Debug)]
+struct QueueInfo {
+    id: SourceId,
+    queue: ReactorQueue,
+    /// Tasks waiting for the next event.
+    waiters: Vec<Waker>,
 }
 
 #[derive(Debug)]
@@ -246,10 +232,9 @@ impl Source {
         Source {
             inner: Rc::new(InnerSource {
                 raw,
-                wakers: RefCell::new(Wakers::new()),
                 source_type: RefCell::new(source_type),
                 io_requirements: ioreq,
-                enqueued: Cell::new(None),
+                state: RefCell::new(SourceState::NotQueued),
             }),
         }
     }

--- a/scipio/src/sys/uring.rs
+++ b/scipio/src/sys/uring.rs
@@ -8,12 +8,12 @@ use rlimit::Resource;
 use std::cell::{Cell, Ref, RefCell};
 use std::collections::VecDeque;
 use std::ffi::CStr;
-use std::io;
 use std::io::{Error, ErrorKind};
 use std::os::unix::io::RawFd;
 use std::rc::Rc;
 use std::task::Waker;
 use std::time::Duration;
+use std::{io, mem};
 
 use crate::free_list::{FreeList, Idx};
 use crate::sys::posix_buffers::PosixDmaBuffer;
@@ -22,7 +22,7 @@ use crate::{IoRequirements, Latency};
 
 use uring_sys::IoRingOp;
 
-use super::{EnqueuedSource, TimeSpec64};
+use super::{QueueInfo, SourceState, TimeSpec64};
 
 type DmaBuffer = PosixDmaBuffer;
 
@@ -220,16 +220,18 @@ where
             return Some(());
         }
 
-        let src = consume_source(from_user_data(value.user_data()));
+        let (src, mut queue_info) = consume_source(from_user_data(value.user_data()));
 
         let result = value.result();
         let was_cancelled =
             matches!(&result, Err(err) if err.raw_os_error() == Some(libc::ECANCELED));
 
         if !was_cancelled && try_process(&*src).is_none() {
-            let mut w = src.wakers.borrow_mut();
-            w.result = Some(result);
-            wakers.append(&mut w.waiters);
+            let new_state = SourceState::Ready { result };
+            let old_state = src.transition(new_state);
+            assert!(matches!(old_state, SourceState::NotQueued));
+
+            wakers.append(&mut queue_info.waiters);
         }
         return Some(());
     }
@@ -251,10 +253,15 @@ fn add_source(source: &Source, queue: ReactorQueue) -> SourceId {
     SOURCE_MAP.with(|x| {
         let item = source.inner.clone();
         let id = x.borrow_mut().alloc(item);
-        source.inner.enqueued.set(Some(EnqueuedSource {
+
+        let new_state = SourceState::Queued(QueueInfo {
             id,
-            queue: queue.clone(),
-        }));
+            queue,
+            waiters: Vec::new(),
+        });
+        let old_state = source.inner.transition(new_state);
+        assert!(matches!(old_state, SourceState::NotQueued));
+
         id
     })
 }
@@ -263,11 +270,22 @@ fn peek_source(id: SourceId) -> Rc<InnerSource> {
     SOURCE_MAP.with(|x| Rc::clone(&x.borrow()[id]))
 }
 
-fn consume_source(id: SourceId) -> Rc<InnerSource> {
+fn consume_source(id: SourceId) -> (Rc<InnerSource>, QueueInfo) {
     SOURCE_MAP.with(|x| {
         let source = x.borrow_mut().dealloc(id);
-        source.enqueued.set(None);
-        source
+
+        let new_state = SourceState::NotQueued;
+        let old_state = source.transition(new_state);
+
+        match old_state {
+            SourceState::Queued(queue_info) => (source, queue_info),
+            SourceState::NotQueued | SourceState::Ready { .. } | SourceState::Consumed => {
+                unreachable!(
+                    "Source {:?} should be in Queued state, was in {:?}",
+                    id, old_state
+                )
+            }
+        }
     })
 }
 
@@ -470,6 +488,10 @@ impl InnerSource {
     pub(crate) fn update_source_type(&self, source_type: SourceType) -> SourceType {
         std::mem::replace(&mut *self.source_type.borrow_mut(), source_type)
     }
+
+    fn transition(&self, new_state: SourceState) -> SourceState {
+        mem::replace(&mut *self.state.borrow_mut(), new_state)
+    }
 }
 
 impl Source {
@@ -508,12 +530,23 @@ impl Source {
     }
 
     pub(crate) fn take_result(&self) -> Option<io::Result<usize>> {
-        let mut w = self.inner.wakers.borrow_mut();
-        w.result.take()
+        if let SourceState::Queued(..) = &*self.inner.state.borrow() {
+            return None;
+        }
+        let old_state = self.inner.transition(SourceState::Consumed);
+        match old_state {
+            SourceState::Ready { result } => Some(result),
+            SourceState::Queued(..) => unreachable!(),
+            SourceState::Consumed => panic!("Attempting to get a result from Source twice"),
+            SourceState::NotQueued => {
+                panic!("Attempting to get a result from Source, which wasn't queued")
+            }
+        }
     }
     pub(crate) fn add_waiter(&self, waker: Waker) {
-        let mut w = self.inner.wakers.borrow_mut();
-        w.waiters.push(waker);
+        if let SourceState::Queued(queue_info) = &mut *self.inner.state.borrow_mut() {
+            queue_info.waiters.push(waker)
+        }
     }
 
     pub(crate) fn raw(&self) -> RawFd {
@@ -523,7 +556,11 @@ impl Source {
 
 impl Drop for Source {
     fn drop(&mut self) {
-        if let Some(EnqueuedSource { id, queue }) = self.inner.enqueued.take() {
+        let state = self.inner.state.borrow();
+        if let SourceState::Queued(queue_info) = &*state {
+            let queue = queue_info.queue.clone();
+            let id = queue_info.id;
+            drop(state);
             queue.borrow_mut().cancel_request(id);
         }
     }


### PR DESCRIPTION
### What does this PR do?

Refactoring, encoding Source state transitions as an enum.

@glommer this currently fails the test, because `preempt_timer` functions actually do violate state transition assumptions I think are reasonable to make. Why these functions are "hand-codeed", instead of using the standard code-path of `queue_request_into_ring` and `consume_source`? Why do we need to track SourceId/user_data via `SourceType::Timeout.0` for timeouts, but not for other requests? 

Is there perhaps some high-level irregularity with this preempt_timer I am missing? 


[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
[x] The new code I am adding is formatted using `rustfmt`
