### PR TITLE
Simplify handling of timeouts

### DIFF
--- a/scipio/src/sys/mod.rs
+++ b/scipio/src/sys/mod.rs
@@ -136,7 +136,7 @@ pub(crate) enum SourceType {
     Close,
     LinkRings(LinkStatus),
     Statx(CString, Box<RefCell<libc::statx>>),
-    Timeout(Option<u64>, TimeSpec64),
+    Timeout(TimeSpec64),
     Invalid,
 }
 


### PR DESCRIPTION
### What does this PR do?

Leverage `Source::drop` for cancellation of ring's timer.

### Motivation

Mainly to get rid of "single source is present twice in the SourceMap" condition, but also just to reduce the amount of code

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
[x] The new code I am adding is formatted using `rustfmt`
