### PR TITLE
Remove no-op cancellations

### DIFF
--- a/scipio/src/io/dma_file_stream.rs
+++ b/scipio/src/io/dma_file_stream.rs
@@ -138,9 +138,7 @@ struct DmaStreamReaderState {
 impl DmaStreamReaderState {
     fn discard_buffer(&mut self, id: u64) {
         self.buffermap.remove(&id);
-        if let Some(handle) = self.pending.remove(&id) {
-            handle.cancel();
-        }
+        self.pending.remove(&id);
     }
 
     fn replenish_read_ahead(&mut self, state: Rc<RefCell<Self>>, file: Rc<DmaFile>) {
@@ -236,14 +234,6 @@ impl DmaStreamReaderState {
             handles.push(v);
         }
         handles
-    }
-}
-
-impl Drop for DmaStreamReaderState {
-    fn drop(&mut self) {
-        for (_k, v) in self.pending.drain() {
-            v.cancel();
-        }
     }
 }
 
@@ -798,14 +788,6 @@ impl DmaStreamWriterState {
             })
             .detach(),
         );
-    }
-}
-
-impl Drop for DmaStreamWriterState {
-    fn drop(&mut self) {
-        for (_, v) in self.pending.drain() {
-            v.cancel();
-        }
     }
 }
 


### PR DESCRIPTION
### What does this PR do?

`JoinHandle`s implement structured concurrency and already do
cancellation in drop, so there's no need for explicit cancellations.

### Additional Notes

One interesting thing I've noticed is that both `.cancel` and `.drop` are sync. Ideally, you'd `.await` for task after its cancellation. I am not sure how this should interact with scipio:

* on the one hand, because executor runs on a single thread, I *think* we can implement fully synchronous task cancellation, such that `cancel` immediately frees all task's resources. 
* on the other hand, the cancellation *should* be fully async. Let's say we have a task, which is waiting on an uring operation. Currently, when we cancel the task, we just enqueue cancellation operation into uring and, IIUC, we never actually await for the cancellation to happen. So, if you allocate 10GB buffer to do a read, and then cancel the read, that task will return from `.await` reporting that the cancellation concluded, but there still be 10GB buffer in the SourceMap for some time. 


### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
[x] The new code I am adding is formatted using `rustfmt`
