### PR TITLE
change calculation of active tasks

### DIFF
--- a/scipio/src/executor.rs
+++ b/scipio/src/executor.rs
@@ -175,9 +175,7 @@ impl TaskQueue {
     }
 
     fn get_task(&mut self) -> Option<multitask::Runnable> {
-        let r = self.ex.get_task();
-        self.active = r.is_some();
-        r
+        self.ex.get_task()
     }
 
     fn yielded(&self) -> bool {
@@ -198,6 +196,8 @@ impl TaskQueue {
         let delta_scaled = (self.stats.reciprocal_shares * (delta.as_nanos() as u64)) >> 12;
         self.stats.runtime += delta;
         self.stats.queue_selected += 1;
+        self.active = self.ex.is_active();
+
         let vruntime = self.vruntime.checked_add(delta_scaled);
         if let Some(x) = vruntime {
             self.vruntime = x;

--- a/scipio/src/multitask.rs
+++ b/scipio/src/multitask.rs
@@ -200,6 +200,10 @@ impl LocalExecutor {
     pub(crate) fn get_task(&self) -> Option<Runnable> {
         self.local_queue.pop()
     }
+
+    pub(crate) fn is_active(&self) -> bool {
+        !self.local_queue.queue.borrow().is_empty()
+    }
 }
 
 /// A cloneable callback function.


### PR DESCRIPTION
We determine whether or not a task is active based on whether we popped
the last element of the queue.

That worked well before we checked for preemption, because if we are processing
the last element of the queue now, we'll try to enter the loop once more and
conclude the tq is now inactive.

But with preemption we may end up popping the last element and breaking the loop
before we try again. In that case the task queue is inactive but we never marked
it as so.

We always call account_vruntime for every run so it is better to defer the
decision on whether to mark a task as inactive until that point.

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
[] The new code I am adding is formatted using `rustfmt`
