### PR TITLE
simplify task spawning and change its visibility

### DIFF
--- a/scipio/src/task/mod.rs
+++ b/scipio/src/task/mod.rs
@@ -7,85 +7,16 @@
 //!
 //! # Spawning
 //!
-//! To spawn a future onto an executor, we first need to allocate it on the heap and keep some
+//! To spawn a future onto the Scipio executor, we first need to allocate it on the heap and keep some
 //! state alongside it. The state indicates whether the future is ready for polling, waiting to be
 //! woken up, or completed. Such a future is called a *task*.
-//!
-//! All executors have some kind of queue that holds runnable tasks:
-//!
-//! ```
-//! # use std::sync::mpsc::sync_channel;
-//! #
-//! # // a queue of task to eventually execute
-//! # let (sender, receiver) = sync_channel(10);
-//! #
-//! # // A future that will get spawned.
-//! # let future = async { 1 + 2 };
-//! #
-//! # // A function that schedules the task when it gets woken up.
-//! # let schedule = move |task| sender.send(task).unwrap();
-//! #
-//! # // Construct a task.
-//! # let (task, handle) = scipio::task::spawn(future, schedule, ());
-//! ```
-//!
-//! A task is constructed using either [`spawn`] or [`spawn_local`]:
-//!
-//! ```
-//! # use std::sync::mpsc::sync_channel;
-//! #
-//! # // a queue of task to eventually execute
-//! # let (sender, receiver) = sync_channel(10);
-//! #
-//! // A future that will be spawned.
-//! let future = async { 1 + 2 };
-//!
-//! // A function that schedules the task when it gets woken up.
-//! let schedule = move |task| sender.send(task).unwrap();
-//!
-//! // Construct a task.
-//! let (task, handle) = scipio::task::spawn(future, schedule, ());
-//!
-//! // Push the task into the queue by invoking its schedule function.
-//! task.schedule();
-//! ```
-//!
-//! The last argument to the [`spawn`] function is a *tag*, an arbitrary piece of data associated
-//! with the task. In most executors, this is typically a task identifier or task-local storage.
-//!
-//! The function returns a runnable [`Task`] and a [`JoinHandle`] that can await the result.
-//!
-//! # Execution
-//!
-//! Task executors have some kind of main loop that drives tasks to completion. That means taking
-//! runnable tasks out of the queue and running each one in order:
-//!
-//! ```no_run
-//! # use std::sync::mpsc::sync_channel;
-//! #
-//! # // a queue of task to eventually execute
-//! # let (sender, receiver) = sync_channel(10);
-//! #
-//! # // A future that will get spawned.
-//! # let future = async { 1 + 2 };
-//! #
-//! # // A function that schedules the task when it gets woken up.
-//! # let schedule = move |task| sender.send(task).unwrap();
-//! #
-//! # // Construct a task.
-//! # let (task, handle) = scipio::task::spawn(future, schedule, ());
-//! #
-//! # // Push the task into the queue by invoking its schedule function.
-//! # task.schedule();
-//! #
-//! for task in receiver {
-//!     task.run();
-//! }
-//! ```
 //!
 //! When a task is run, its future gets polled. If polling does not complete the task, that means
 //! it's waiting for another future and needs to go to sleep. When woken up, its schedule function
 //! will be invoked, pushing it back into the queue so that it can be run again.
+//!
+//! Paired with a task there usually is a [`JoinHandle`] that can be used to wait for the task's
+//! completion.
 //!
 //! # Cancellation
 //!
@@ -120,15 +51,11 @@
 //! waker.wake_by_ref();
 //! ```
 //!
-//! This is useful for implementing single-future executors like [`block_on`].
-//!
-//! [`spawn`]: fn.spawn.html
 //! [`spawn_local`]: fn.spawn_local.html
 //! [`waker_fn`]: fn.waker_fn.html
 //! [`Task`]: struct.Task.html
 //! [`JoinHandle`]: struct.JoinHandle.html
 //! [`Waker`]: https://doc.rust-lang.org/std/task/struct.Waker.html
-//! [`block_on`]: https://github.com/async-rs/async-task/blob/master/examples/block.rs
 
 #![warn(missing_docs, missing_debug_implementations)]
 #![doc(test(attr(deny(rust_2018_idioms, warnings))))]
@@ -143,5 +70,5 @@ pub(crate) mod utils;
 pub(crate) mod waker_fn;
 
 pub use crate::task::join_handle::JoinHandle;
-pub use crate::task::task_impl::{spawn, spawn_local, Task};
+pub use crate::task::task_impl::Task;
 pub use crate::task::waker_fn::waker_fn;


### PR DESCRIPTION
Our task implementation comes from async-task, with heavy modifications
to run in a thread-per-core environment (nothing is Send, etc).

There is still some cleanup work to be done there, and this is a first step:

* While the task and join handle structs are and should be public, most
  methods (like spawn_local) shouldn't be: they have to be called through
  the executor so we can provide the right guarantees

* The documentation is terribly outdated, speak about executors in general,
  and simply will not compile when we remove the visibility of spawn_local.

* It uses expensive TLS checks to guarantee on Drop that we were dropped by the
  same thread in which we were spawn. However with Scipio guarantees on the executor
  side it is impossible to be otherwise.

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
[] The new code I am adding is formatted using `rustfmt`
